### PR TITLE
Motors now use `.move`

### DIFF
--- a/ez-template-docs/docs/pid.md
+++ b/ez-template-docs/docs/pid.md
@@ -81,7 +81,7 @@ void opcontrol() {
     else if (master.get_digital(DIGITAL_L2)) {
       liftPID.target_set(0);
     }
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
 
     pros::delay(ez::util::DELAY_TIME);
   }
@@ -137,7 +137,7 @@ void opcontrol() {
       target = 0.0;
     }
     error = target - lift_motor.get_position();
-    lift_motor = liftPID.compute_error(error, lift_motor.get_position());
+    lift_motor.move(liftPID.compute_error(error, lift_motor.get_position()));
 
     pros::delay(ez::util::DELAY_TIME);
   }
@@ -236,7 +236,7 @@ void opcontrol() {
     else if (master.get_digital(DIGITAL_L2)) {
       liftPID.target_set(0);
     }
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
 
     pros::delay(ez::util::DELAY_TIME);
   }
@@ -549,7 +549,7 @@ void opcontrol() {
       liftPID.target_set(0);
       printf("%.2f\n", liftPID.target_get()); // This prints 0
     }
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
 
     pros::delay(ez::util::DELAY_TIME);
   }
@@ -772,13 +772,13 @@ void initialize() {
 void autonomous() {
   liftPID.target_set(500);
   while (liftPID.exit_condition(true) == ez::RUNNING) {
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
     pros::delay(ez::util::DELAY_TIME);
   }
 
   liftPID.target_set(0);
   while (liftPID.exit_condition(true) == ez::RUNNING) {
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
     pros::delay(ez::util::DELAY_TIME);
   }
 }
@@ -832,13 +832,13 @@ void initialize() {
 void autonomous() {
   liftPID.target_set(500);
   while (liftPID.exit_condition(lift_motor, true) == ez::RUNNING) {
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
     pros::delay(ez::util::DELAY_TIME);
   }
 
   liftPID.target_set(0);
   while (liftPID.exit_condition(lift_motor, true) == ez::RUNNING) {
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
     pros::delay(ez::util::DELAY_TIME);
   }
 }
@@ -886,8 +886,8 @@ pros::Motor l_lift_motor(1);
 pros::Motor r_lift_motor(2, true);
 
 void set_lift(int input) {
-  l_lift_motor = input;
-  r_lift_motor = input;
+  l_lift_motor.move(input);
+  r_lift_motor.move(input);
 }
 
 void initialize() {
@@ -952,7 +952,7 @@ void opcontrol() {
       liftPID.timers_reset();
       liftPID.target_set(0);
     }
-    lift_motor = liftPID.compute(lift_motor.get_position());
+    lift_motor.move(liftPID.compute(lift_motor.get_position()));
 
     pros::delay(ez::util::DELAY_TIME);
   }

--- a/ez-template-docs/tutorials/intake_control.md
+++ b/ez-template-docs/tutorials/intake_control.md
@@ -99,13 +99,13 @@ void opcontrol() {
     // . . .
 
     if (master.get_digital(DIGITAL_L1)) {
-      intake = 127;
+      intake.move(127);
     } 
     else if (master.get_digital(DIGITAL_L2)) {
-      intake = -127;
+      intake.move(-127);
     } 
     else {
-      intake = 0;
+      intake.move(0);
     }
 
     pros::delay(ez::util::DELAY_TIME);  // This is used for timer calculations!  Keep this ez::util::DELAY_TIME
@@ -119,9 +119,9 @@ Now that the motor is created in `subsystems.hpp` we can access it in our autono
 void intake_autonomous() {
   chassis.pid_drive_set(24_in, DRIVE_SPEED, true);
   chassis.pid_wait_until(6_in);
-  intake = 127;
+  intake.move(127);
   chassis.pid_wait_quick_chain();
-  intake = 0;
+  intake.move(0);
 
   chassis.pid_turn_set(45_deg, TURN_SPEED);
   chassis.pid_wait_quick_chain();
@@ -132,11 +132,11 @@ void intake_autonomous() {
   chassis.pid_turn_set(0_deg, TURN_SPEED);
   chassis.pid_wait();
 
-  intake = -127;
+  intake.move(-127);
   chassis.pid_drive_set(-24_in, DRIVE_SPEED, true);
   chassis.pid_speed_max_set(DRIVE_SPEED);  
   chassis.pid_wait();
-  intake = 0;
+  intake.move(0);
 }
 ```
 

--- a/ez-template-docs/tutorials/pid.md
+++ b/ez-template-docs/tutorials/pid.md
@@ -12,8 +12,8 @@ This code uses a function called `set_lift` to set the power of 2 lift motors in
 pros::Motor l_lift(17);
 pros::Motor r_lift(18);
 void set_lift(int input) {
-  l_lift = input;
-  r_lift = input;
+  l_lift.move(input);
+  r_lift.move(input);
 }
 ez::PID liftPID{0.45, 0, 0, 0, "Lift"};
 
@@ -44,8 +44,8 @@ We've added a new function called `lift_auto()`.  This function takes in a targ
 pros::Motor l_lift(17);
 pros::Motor r_lift(18);
 void set_lift(int input) {
- l_lift = input;
- r_lift = input;
+  l_lift.move(input);
+  r_lift.move(input);
 }
 ez::PID liftPID{0.45, 0, 0, 0, "Lift"};
 
@@ -92,8 +92,8 @@ Example 2 has a problem of not being able to do other things while the lift is r
 pros::Motor l_lift(17);
 pros::Motor r_lift(18);
 void set_lift(int input) {
-  l_lift = input;
-  r_lift = input;
+  l_lift.move(input);
+  r_lift.move(input);
 }
 ez::PID liftPID{0.45, 0, 0, 0, "Lift"};
 

--- a/ez-template-docs/tutorials/pto_tutorial.md
+++ b/ez-template-docs/tutorials/pto_tutorial.md
@@ -32,8 +32,8 @@ void pto_toggle_intake(bool toggle) {
 
 void set_intake(int input) {
   if (!pto_intake_enabled) return;
-  chassis.left_motors[LEFT_INTAKE] = input;
-  chassis.right_motors[RIGHT_INTAKE] = input;
+  chassis.left_motors[LEFT_INTAKE].move(input;
+  chassis.right_motors[RIGHT_INTAKE].move(input;
 }
 
 // User control code
@@ -97,8 +97,8 @@ void pto_toggle_intake(bool toggle) {
 void set_intake(int input) {
   pto_toggle_intake(input == 0 ? false : true);
   if (!pto_piston_enabled) return;
-  chassis.left_motors[LEFT_INTAKE] = -input;
-  chassis.right_motors[RIGHT_INTAKE] = -input;
+  chassis.left_motors[LEFT_INTAKE].move(-input);
+  chassis.right_motors[RIGHT_INTAKE].move(-input);
 }
 
 // User control code
@@ -157,8 +157,8 @@ void pto_toggle_intake(bool toggle) {
 // Raw intake function (intended use in this file only)
 void raw_set_intake(int input) {
   if (!pto_piston_enabled) return;
-  chassis.left_motors[LEFT_INTAKE] = -input;
-  chassis.right_motors[RIGHT_INTAKE] = -input;
+  chassis.left_motors[LEFT_INTAKE].move(-input);
+  chassis.right_motors[RIGHT_INTAKE].move(-input);
 }
 
 // Global intake function (for use outside of this file)


### PR DESCRIPTION
Pros 4 no longer supports `motor = x;`.  Docs have been updated to `motor.move(x);`.