### PR TITLE
Fixed tracking inconsistencies 

### DIFF
--- a/EZ-Template-Example-Project/src/main.cpp
+++ b/EZ-Template-Example-Project/src/main.cpp
@@ -11,9 +11,9 @@ ez::Drive chassis(
     {1, 2, 3},     // Left Chassis Ports (negative port will reverse it!)
     {-4, -5, -6},  // Right Chassis Ports (negative port will reverse it!)
 
-    7,      // IMU Port
+    7,      // IMU port
     4.125,  // Wheel Diameter (Remember, 4" wheels without screw holes are actually 4.125!)
-    343);   // Wheel RPM
+    343);   // Wheel RPM = cartridge * (motor gear / wheel gear)
 
 // Are you using tracking wheels?  Comment out which ones you're using here!
 //  `2.75` is the wheel diameter

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -88,22 +88,22 @@ class Drive {
   /**
    * Left vertical tracking wheel.
    */
-  tracking_wheel* odom_left_tracker;
+  tracking_wheel* odom_tracker_left;
 
   /**
    * Right vertical tracking wheel.
    */
-  tracking_wheel* odom_right_tracker;
+  tracking_wheel* odom_tracker_right;
 
   /**
    * Front horizontal tracking wheel.
    */
-  tracking_wheel* odom_front_tracker;
+  tracking_wheel* odom_tracker_front;
 
   /**
    * Back horizontal tracking wheel.
    */
-  tracking_wheel* odom_back_tracker;
+  tracking_wheel* odom_tracker_back;
 
   /**
    * PID objects.
@@ -3070,7 +3070,7 @@ class Drive {
       {"Swing Forward PID Constants", &forward_swingPID.constants},
       {"Swing Backward PID Constants", &backward_swingPID.constants}};
 
-  bool odom_ime_use_left = true;
+  bool odom_use_left = true;
   double odom_ime_track_width_left = 0.0;
   double odom_ime_track_width_right = 0.0;
 
@@ -3121,8 +3121,7 @@ class Drive {
   double max_boomerang_distance = 12.0;
   double odom_turn_bias_amount = 1.375;
   drive_directions current_drive_direction = fwd;
-  double h_last = 0.0, v_last = 0.0, l_last = 0.0, r_last = 0.0;
-  double t_last = 0.0;
+  double h_last = 0.0, t_last = 0.0, l_last = 0.0, r_last = 0.0;
   pose l_pose{0.0, 0.0, 0.0};
   pose r_pose{0.0, 0.0, 0.0};
   pose central_pose{0.0, 0.0, 0.0};
@@ -3144,10 +3143,10 @@ class Drive {
   std::vector<odom> set_odoms_direction(std::vector<odom> inputs);
   odom set_odom_direction(odom input);
   pose flip_pose(pose input);
-  bool odom_left_tracker_enabled = false;
-  bool odom_right_tracker_enabled = false;
-  bool odom_front_tracker_enabled = false;
-  bool odom_back_tracker_enabled = false;
+  bool odom_tracker_left_enabled = false;
+  bool odom_tracker_right_enabled = false;
+  bool odom_tracker_front_enabled = false;
+  bool odom_tracker_back_enabled = false;
 
   double chain_target_start = 0.0;
   double chain_sensor_start = 0.0;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -237,7 +237,7 @@ void Drive::drive_defaults_set() {
 
 double Drive::drive_tick_per_inch() {
   if (is_tracker == ODOM_TRACKER)
-    return odom_right_tracker->ticks_per_inch();
+    return odom_tracker_right->ticks_per_inch();
 
   CIRCUMFERENCE = WHEEL_DIAMETER * M_PI;
 
@@ -296,12 +296,16 @@ int Drive::drive_current_limit_get() {
 
 // Motor telemetry
 void Drive::drive_sensor_reset() {
-  v_last = 0.0;
   h_last = 0.0;
   l_last = 0.0;
   r_last = 0.0;
+  t_last = 0.0;
   left_motors.front().tare_position();
   right_motors.front().tare_position();
+  if (odom_tracker_left_enabled) odom_tracker_left->reset();
+  if (odom_tracker_right_enabled) odom_tracker_right->reset();
+  if (odom_tracker_front_enabled) odom_tracker_front->reset();
+  if (odom_tracker_back_enabled) odom_tracker_back->reset();
   if (is_tracker == DRIVE_ADI_ENCODER) {
     left_tracker.reset();
     right_tracker.reset();
@@ -311,10 +315,6 @@ void Drive::drive_sensor_reset() {
     right_rotation.reset_position();
     return;
   }
-  if (odom_left_tracker_enabled) odom_left_tracker->reset();
-  if (odom_right_tracker_enabled) odom_right_tracker->reset();
-  if (odom_front_tracker_enabled) odom_front_tracker->reset();
-  if (odom_back_tracker_enabled) odom_back_tracker->reset();
 }
 
 int Drive::drive_sensor_right_raw() {
@@ -323,12 +323,12 @@ int Drive::drive_sensor_right_raw() {
   else if (is_tracker == DRIVE_ROTATION)
     return right_rotation.get_position();
   else if (is_tracker == ODOM_TRACKER)
-    return odom_right_tracker->get_raw();
+    return odom_tracker_right->get_raw();
   return right_motors.front().get_position();
 }
 double Drive::drive_sensor_right() {
   if (is_tracker == ODOM_TRACKER)
-    return odom_right_tracker->get();
+    return odom_tracker_right->get();
   return drive_sensor_right_raw() / drive_tick_per_inch();
 }
 int Drive::drive_velocity_right() { return right_motors.front().get_actual_velocity(); }
@@ -341,12 +341,12 @@ int Drive::drive_sensor_left_raw() {
   else if (is_tracker == DRIVE_ROTATION)
     return left_rotation.get_position();
   else if (is_tracker == ODOM_TRACKER)
-    return odom_left_tracker->get_raw();
+    return odom_tracker_left->get_raw();
   return left_motors.front().get_position();
 }
 double Drive::drive_sensor_left() {
   if (is_tracker == ODOM_TRACKER)
-    return odom_left_tracker->get();
+    return odom_tracker_left->get();
   return drive_sensor_left_raw() / drive_tick_per_inch();
 }
 int Drive::drive_velocity_left() { return left_motors.front().get_actual_velocity(); }
@@ -454,40 +454,40 @@ void Drive::initialize() {
 void Drive::odom_tracker_left_set(tracking_wheel* input) {
   if (input == nullptr) return;
 
-  odom_left_tracker = input;
-  odom_left_tracker_enabled = true;
+  odom_tracker_left = input;
+  odom_tracker_left_enabled = true;
 
   // Assume the user input a positive number and set it to a negative number
-  odom_left_tracker->distance_to_center_flip_set(true);
+  odom_tracker_left->distance_to_center_flip_set(true);
 
   // If the user has input a left and right tracking wheel,
   // the tracking wheels become the new sensors always
-  if (odom_right_tracker_enabled)
+  if (odom_tracker_right_enabled)
     is_tracker = ODOM_TRACKER;
 }
 void Drive::odom_tracker_right_set(tracking_wheel* input) {
   if (input == nullptr) return;
 
-  odom_right_tracker = input;
-  odom_right_tracker_enabled = true;
+  odom_tracker_right = input;
+  odom_tracker_right_enabled = true;
 
   // If the user has input a left and right tracking wheel,
   // the tracking wheels become the new sensors always
-  if (odom_left_tracker_enabled)
+  if (odom_tracker_left_enabled)
     is_tracker = ODOM_TRACKER;
 }
 void Drive::odom_tracker_front_set(tracking_wheel* input) {
   if (input == nullptr) return;
 
-  odom_front_tracker = input;
-  odom_front_tracker_enabled = true;
+  odom_tracker_front = input;
+  odom_tracker_front_enabled = true;
 }
 void Drive::odom_tracker_back_set(tracking_wheel* input) {
   if (input == nullptr) return;
 
-  odom_back_tracker = input;
-  odom_back_tracker_enabled = true;
+  odom_tracker_back = input;
+  odom_tracker_back_enabled = true;
 
   // Set the center distance to be negative
-  odom_back_tracker->distance_to_center_flip_set(true);
+  odom_tracker_back->distance_to_center_flip_set(true);
 }

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -195,10 +195,12 @@ void Drive::drive_defaults_set() {
   std::cout << std::setprecision(2);
 
   // PID Constants
-  pid_heading_constants_set(7, 0, 45, 0);
-  pid_drive_constants_set(20, 0, 100, 0);
-  pid_turn_constants_set(3, 0.05, 20, 15);
-  pid_swing_constants_set(6, 0, 65);
+  pid_drive_constants_set(20.0, 0.0, 100.0);
+  pid_heading_constants_set(11.0, 0.0, 20.0);
+  pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);
+  pid_swing_constants_set(6.0, 0.0, 65.0);
+  pid_odom_angular_constants_set(5.5, 0.0, 62.5);
+  pid_odom_boomerang_constants_set(3.5, 0.0, 35.0);
   pid_turn_min_set(30);
   pid_swing_min_set(30);
 
@@ -294,8 +296,10 @@ int Drive::drive_current_limit_get() {
 
 // Motor telemetry
 void Drive::drive_sensor_reset() {
-  v_last = 0;
-  h_last = 0;
+  v_last = 0.0;
+  h_last = 0.0;
+  l_last = 0.0;
+  r_last = 0.0;
   left_motors.front().tare_position();
   right_motors.front().tare_position();
   if (is_tracker == DRIVE_ADI_ENCODER) {
@@ -352,7 +356,7 @@ bool Drive::drive_current_left_over() { return left_motors.front().is_over_curre
 void Drive::drive_imu_reset(double new_heading) {
   imu.set_rotation(new_heading);
   angle_rad = util::to_rad(new_heading);
-  last_theta = angle_rad;
+  t_last = angle_rad;
 }
 double Drive::drive_imu_get() { return imu.get_rotation() * IMU_SCALER; }
 double Drive::drive_imu_accel_get() { return imu.get_accel().x + imu.get_accel().y; }

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -199,7 +199,7 @@ void Drive::drive_defaults_set() {
   pid_heading_constants_set(11.0, 0.0, 20.0);
   pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);
   pid_swing_constants_set(6.0, 0.0, 65.0);
-  pid_odom_angular_constants_set(5.5, 0.0, 62.5);
+  pid_odom_angular_constants_set(5.0, 0.0, 60.0);
   pid_odom_boomerang_constants_set(3.5, 0.0, 35.0);
   pid_turn_min_set(30);
   pid_swing_min_set(30);
@@ -213,8 +213,8 @@ void Drive::drive_defaults_set() {
   pid_turn_exit_condition_set(80_ms, 3_deg, 250_ms, 7_deg, 500_ms, 500_ms);
   pid_swing_exit_condition_set(80_ms, 3_deg, 250_ms, 7_deg, 500_ms, 500_ms);
   pid_drive_exit_condition_set(80_ms, 1_in, 250_ms, 3_in, 500_ms, 500_ms);
-  pid_odom_turn_exit_condition_set(80_ms, 3_deg, 250_ms, 7_deg, 500_ms, 750_ms);
-  pid_odom_drive_exit_condition_set(80_ms, 1_in, 250_ms, 3_in, 500_ms, 750_ms);
+  pid_odom_turn_exit_condition_set(90_ms, 3_deg, 250_ms, 7_deg, 500_ms, 750_ms);
+  pid_odom_drive_exit_condition_set(90_ms, 1_in, 250_ms, 3_in, 500_ms, 750_ms);
 
   pid_turn_chain_constant_set(3_deg);
   pid_swing_chain_constant_set(5_deg);

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -82,8 +82,8 @@ void Drive::pid_odom_drive_exit_condition_set(okapi::QTime p_small_exit_time, ok
 }
 
 void Drive::pid_odom_turn_exit_condition_set(int p_small_exit_time, double p_small_error, int p_big_exit_time, double p_big_error, int p_velocity_exit_time, int p_mA_timeout, bool use_imu) {
-  aPID.exit_condition_set(p_small_exit_time, p_small_error, p_big_exit_time, p_big_error, p_velocity_exit_time, p_mA_timeout);
-  aPID.velocity_sensor_secondary_toggle_set(use_imu);
+  current_a_odomPID.exit_condition_set(p_small_exit_time, p_small_error, p_big_exit_time, p_big_error, p_velocity_exit_time, p_mA_timeout);
+  current_a_odomPID.velocity_sensor_secondary_toggle_set(use_imu);
 }
 
 void Drive::pid_odom_turn_exit_condition_set(okapi::QTime p_small_exit_time, okapi::QAngle p_small_error, okapi::QTime p_big_exit_time, okapi::QAngle p_big_error, okapi::QTime p_velocity_exit_time, okapi::QTime p_mA_timeout, bool use_imu) {
@@ -129,12 +129,12 @@ void Drive::pid_wait() {
     if (mode == PURE_PURSUIT) {
       while (pp_index != pp_movements.size() - 1) {
         xyPID.velocity_sensor_secondary_set(drive_imu_accel_get());
-        aPID.velocity_sensor_secondary_set(drive_imu_accel_get());
+        current_a_odomPID.velocity_sensor_secondary_set(drive_imu_accel_get());
         xy_exit = xy_exit != RUNNING ? xy_exit : xyPID.exit_condition({left_motors[0], right_motors[0]});
-        a_exit = a_exit != RUNNING ? a_exit : aPID.exit_condition({left_motors[0], right_motors[0]});
+        a_exit = a_exit != RUNNING ? a_exit : current_a_odomPID.exit_condition({left_motors[0], right_motors[0]});
 
         if ((xy_exit == mA_EXIT || xy_exit == VELOCITY_EXIT) && (a_exit == mA_EXIT || a_exit == VELOCITY_EXIT)) {
-          if (print_toggle) std::cout << "  XY: " << exit_to_string(xy_exit) << " Exited early, error: " << xyPID.error << ".   Angle: " << exit_to_string(a_exit) << " Exited early, error: " << aPID.error << ".\n";
+          if (print_toggle) std::cout << "  XY: " << exit_to_string(xy_exit) << " Exited early, error: " << xyPID.error << ".   Angle: " << exit_to_string(a_exit) << " Exited early, error: " << current_a_odomPID.error << ".\n";
           break;
         }
 
@@ -145,12 +145,12 @@ void Drive::pid_wait() {
     // When we're at the last point in PP / we're just going to point
     while (xy_exit == RUNNING || a_exit == RUNNING) {
       xyPID.velocity_sensor_secondary_set(drive_imu_accel_get());
-      aPID.velocity_sensor_secondary_set(drive_imu_accel_get());
+      current_a_odomPID.velocity_sensor_secondary_set(drive_imu_accel_get());
       xy_exit = xy_exit != RUNNING ? xy_exit : xyPID.exit_condition({left_motors[0], right_motors[0]});
-      a_exit = a_exit != RUNNING ? a_exit : aPID.exit_condition({left_motors[0], right_motors[0]});
+      a_exit = a_exit != RUNNING ? a_exit : current_a_odomPID.exit_condition({left_motors[0], right_motors[0]});
       pros::delay(util::DELAY_TIME);
     }
-    if (print_toggle) std::cout << "  XY: " << exit_to_string(xy_exit) << " Exit, error: " << xyPID.error << ".   Angle: " << exit_to_string(a_exit) << " Exit, error: " << aPID.error << ".\n";
+    if (print_toggle) std::cout << "  XY: " << exit_to_string(xy_exit) << " Exit, error: " << xyPID.error << ".   Angle: " << exit_to_string(a_exit) << " Exit, error: " << current_a_odomPID.error << ".\n";
 
     if (xy_exit == mA_EXIT || xy_exit == VELOCITY_EXIT || a_exit == mA_EXIT || a_exit == VELOCITY_EXIT) {
       interfered = true;
@@ -355,30 +355,30 @@ void Drive::pid_wait_until(double target) {
 void Drive::pid_wait_until_point(pose target) {
   pros::delay(10);
 
-  int xy_sgn = util::sgn(is_past_target(target, odom_current));
+  int xy_sgn = util::sgn(is_past_target(target, odom_pose_get()));
 
   exit_output xy_exit = RUNNING;
   exit_output a_exit = RUNNING;
 
   while (true) {
     xyPID.velocity_sensor_secondary_set(drive_imu_accel_get());
-    aPID.velocity_sensor_secondary_set(drive_imu_accel_get());
+    current_a_odomPID.velocity_sensor_secondary_set(drive_imu_accel_get());
     xy_exit = xy_exit != RUNNING ? xy_exit : xyPID.exit_condition({left_motors[0], right_motors[0]});
-    a_exit = a_exit != RUNNING ? a_exit : aPID.exit_condition({left_motors[0], right_motors[0]});
+    a_exit = a_exit != RUNNING ? a_exit : current_a_odomPID.exit_condition({left_motors[0], right_motors[0]});
 
     if (xy_exit != RUNNING && a_exit != RUNNING) {
       if (print_toggle) {
-        std::cout << "  XY: " << exit_to_string(xy_exit) << " Wait Until Exit Failsafe, triggered at (" << odom_current.x << ", " << odom_current.y << ") instead of (" << target.x << ", " << target.y << ")\n";
+        std::cout << "  XY: " << exit_to_string(xy_exit) << " Wait Until Exit Failsafe, triggered at (" << odom_x_get() << ", " << odom_y_get() << ") instead of (" << target.x << ", " << target.y << ")\n";
         xyPID.timers_reset();
-        aPID.timers_reset();
+        current_a_odomPID.timers_reset();
       }
       return;
     }
 
-    if (util::sgn((is_past_target(target, odom_current))) != xy_sgn) {
-      if (print_toggle) printf("  XY Wait Until Exit Success, triggered at (%.2f, %.2f).  Target: (%.2f, %.2f)\n", odom_current.x, odom_current.y, target.x, target.y);
+    if (util::sgn((is_past_target(target, odom_pose_get()))) != xy_sgn) {
+      if (print_toggle) printf("  XY Wait Until Exit Success, triggered at (%.2f, %.2f).  Target: (%.2f, %.2f)\n", odom_x_get(), odom_y_get(), target.x, target.y);
       xyPID.timers_reset();
-      aPID.timers_reset();
+      current_a_odomPID.timers_reset();
       return;
     }
 
@@ -403,15 +403,15 @@ void Drive::pid_wait_until_index(int index) {
   exit_output a_exit = RUNNING;
   while (pp_index < injected_pp_index[index]) {
     xyPID.velocity_sensor_secondary_set(drive_imu_accel_get());
-    aPID.velocity_sensor_secondary_set(drive_imu_accel_get());
+    current_a_odomPID.velocity_sensor_secondary_set(drive_imu_accel_get());
     xy_exit = xy_exit != RUNNING ? xy_exit : xyPID.exit_condition({left_motors[0], right_motors[0]});
-    a_exit = a_exit != RUNNING ? a_exit : aPID.exit_condition({left_motors[0], right_motors[0]});
+    a_exit = a_exit != RUNNING ? a_exit : current_a_odomPID.exit_condition({left_motors[0], right_motors[0]});
 
     if (xy_exit != RUNNING && a_exit != RUNNING) {
       if (print_toggle) {
-        std::cout << "  XY: " << exit_to_string(xy_exit) << " Wait Until Exit Failsafe, triggered at (" << odom_current.x << ", " << odom_current.y << ") instead of (" << pp_movements[index].target.x << ", " << pp_movements[index].target.y << ")\n";
+        std::cout << "  XY: " << exit_to_string(xy_exit) << " Wait Until Exit Failsafe, triggered at (" << odom_x_get() << ", " << odom_y_get() << ") instead of (" << pp_movements[index].target.x << ", " << pp_movements[index].target.y << ")\n";
         xyPID.timers_reset();
-        aPID.timers_reset();
+        current_a_odomPID.timers_reset();
       }
       break;
     }

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -245,10 +245,10 @@ void Drive::ptp_task() {
   if (print_debug) printf("      a err: %.2f\n", current_a_odomPID.error);
 
   // printf("lr out (%.2f, %.2f)   fwd curveZ(%.2f, %.2f)   lr slew (%.2f, %.2f)\n", l_out, r_out, xy_out, a_out, slew_left.output(), slew_right.output());
-  // printf("max_slew_out %.2f      headingerr: %.2f\n", max_slew_out, current_a_odomPID.error);
+  // printf("max_slew_out %.2f      headingerr: %.2f\n", max_slew_out, aPID.error);
   // printf("lr(%.2f, %.2f)   xy_raw: %.2f   xy_out: %.2f   heading_out: %.2f      max_slew_out: %.2f\n", l_out, r_out, xyPID.output, xy_out, current_a_odomPID.output, max_slew_out);
-  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   current_a_odomPID: %.2f     dir: %i   sgn: %i   past_target: %i    is_past_target: %i   is_past_using_xy: %i      fake_xy(%.2f, %.2f, %.2f)\n", odom_x_get(), odom_y_get(), odom_theta_get(), xyPID.target_get(), current_a_odomPID.target_get(), dir, flipped, past_target, (int)is_past_target(odom_target, odom_pose_get()), is_past_target_using_xy, fake_x, fake_y, util::to_deg(fake_angle));
-  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   current_a_odomPID: %.2f   ptf:(%.2f, %.2f)\n", odom_x_get(), odom_y_get(), odom_theta_get(), xyPID.error, current_a_odomPID.error, ptf.x, ptf.y);
+  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   aPID: %.2f     dir: %i   sgn: %i   past_target: %i    is_past_target: %i   is_past_using_xy: %i      fake_xy(%.2f, %.2f, %.2f)\n", odom_x_get(), odom_y_get(), odom_theta_get(), xyPID.target_get(), current_a_odomPID.target_get(), dir, flipped, past_target, (int)is_past_target(odom_target, odom_pose_get()), is_past_target_using_xy, fake_x, fake_y, util::to_deg(fake_angle));
+  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   aPID: %.2f   ptf:(%.2f, %.2f)\n", odom_x_get(), odom_y_get(), odom_theta_get(), xyPID.error, current_a_odomPID.error, ptf.x, ptf.y);
 
   // Set motors
   if (drive_toggle)

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -11,40 +11,37 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 using namespace ez;
 
 void Drive::ez_auto_task() {
-  int timer = 0;
   while (true) {
-    if (timer >= util::DELAY_TIME) {
-      // Autonomous PID
-      switch (drive_mode_get()) {
-        case DRIVE:
-          drive_pid_task();
-          break;
-        case TURN ... TURN_TO_POINT:
-          turn_pid_task();
-          break;
-        case SWING:
-          swing_pid_task();
-          break;
-        case POINT_TO_POINT:
-          ptp_task();
-          break;
-        case PURE_PURSUIT:
-          pp_task();
-          break;
-        case DISABLE:
-          break;
-        default:
-          break;
-      }
-
-      util::AUTON_RAN = drive_mode_get() != DISABLE ? true : false;
-
-      timer = 0;
+    // Autonomous PID
+    switch (drive_mode_get()) {
+      case DRIVE:
+        drive_pid_task();
+        break;
+      case TURN ... TURN_TO_POINT:
+        turn_pid_task();
+        break;
+      case SWING:
+        swing_pid_task();
+        break;
+      case POINT_TO_POINT:
+        ptp_task();
+        break;
+      case PURE_PURSUIT:
+        pp_task();
+        break;
+      case DISABLE:
+        break;
+      default:
+        break;
     }
 
+    // This is used to reset sensors for active braking
+    util::AUTON_RAN = drive_mode_get() != DISABLE ? true : false;
+
+    // Run odom
     ez_tracking_task();
-    pros::delay(1);
-    timer += 1;
+
+    pros::delay(ez::util::DELAY_TIME);
   }
 }
 
@@ -68,8 +65,8 @@ void Drive::drive_pid_task() {
   double max_slew_out = fmax(slew_left.output(), slew_right.output());
   double faster_side = fmax(fabs(l_drive_out), fabs(r_drive_out));
   if (faster_side > max_slew_out) {
-    l_drive_out = l_drive_out * (max_slew_out / faster_side);
-    r_drive_out = r_drive_out * (max_slew_out / faster_side);
+    l_drive_out *= (max_slew_out / faster_side);
+    r_drive_out *= (max_slew_out / faster_side);
   }
 
   // Toggle heading
@@ -83,8 +80,8 @@ void Drive::drive_pid_task() {
   max_slew_out = fmax(slew_left.output(), slew_right.output());
   faster_side = fmax(fabs(l_out), fabs(r_out));
   if (faster_side > max_slew_out) {
-    l_out = l_out * (max_slew_out / faster_side);
-    r_out = r_out * (max_slew_out / faster_side);
+    l_out *= (max_slew_out / faster_side);
+    r_out *= (max_slew_out / faster_side);
   }
 
   // Set motors
@@ -100,10 +97,10 @@ void Drive::turn_pid_task() {
   }
   // Compute PID if we're turning to point
   else {
-    double a_target = util::absolute_angle_to_point(point_to_face[!ptf1_running], odom_current);  // Calculate the point for angle to face
+    double a_target = util::absolute_angle_to_point(point_to_face[!ptf1_running], odom_pose_get());  // Calculate the point for angle to face
     a_target = new_turn_target_compute(a_target, odom_imu_start, current_angle_behavior);
-    double error = a_target - drive_imu_get();
-    turnPID.compute_error(error, drive_imu_get());
+    double error = a_target - odom_theta_get();
+    turnPID.compute_error(error, odom_theta_get());
   }
 
   // Compute slew
@@ -160,60 +157,98 @@ void Drive::swing_pid_task() {
 
 // Odom To Point Task
 void Drive::ptp_task() {
+  bool print_debug = false;
+
   // Compute slew
   slew_left.iterate(drive_sensor_left());
   slew_right.iterate(drive_sensor_right());
   double max_slew_out = fmax(slew_left.output(), slew_right.output());
+  // double new_max_slew_out = max_slew_out * 2.0;
 
   // Decide if we've past the target or not
-  int dir = (current_drive_direction == REV ? -1 : 1);                                                    // If we're going backwards, add a -1
-  int flipped = util::sgn(is_past_target(odom_target, odom_current)) != util::sgn(past_target) ? -1 : 1;  // Check if we've flipped directions to what we started
+  int dir = (current_drive_direction == REV ? -1 : 1);                                                       // If we're going backwards, add a -1
+  int flipped = util::sgn(is_past_target(odom_target, odom_pose_get())) != util::sgn(past_target) ? -1 : 1;  // Check if we've flipped directions to what we started
 
   // Compute xy PID
-  double temp_target = fabs(is_past_target(odom_target, odom_current));  // Use this instead of distance formula to fix impossible movements
-  xyPID.compute_error(temp_target * dir * flipped, odom_current.x + odom_current.y);
+  double temp_target = fabs(is_past_target(odom_target, odom_pose_get()));  // Use this instead of distance formula to fix impossible movements
+  xyPID.compute_error(temp_target * dir * flipped, odom_x_get() + odom_y_get());
 
   // Compute angle
   pose ptf = point_to_face[!ptf1_running];
-  double a_target = util::absolute_angle_to_point(ptf, odom_current);  // Calculate the point for angle to face
+  double a_target = util::absolute_angle_to_point(ptf, odom_pose_get());  // Calculate the point for angle to face
   a_target = new_turn_target_compute(a_target, odom_imu_start, current_angle_behavior);
-  double wrapped_a_target = a_target - drive_imu_get();
-  aPID.compute_error(wrapped_a_target, drive_imu_get());
+  double wrapped_a_target = a_target - odom_theta_get();
+  current_a_odomPID.compute_error(wrapped_a_target, odom_theta_get());
   // printf("shortest_a_target: %.2f      error: %.2f\n", a_target, wrapped_a_target);
+
+  // if (!print_debug) printf("kp: %.2f    ki: %.5f    kd: %.2f    start_i: %.2f        thratio: %.2f    hratio: %.2f    tratio: %.2f    angle err: %.2f\n", kp, ki, kd, kstart_i, turn_heading_ratio, heading_ratio, turning_ratio, current_a_odomPID.error);
+
+  double rawxyout = 0.0;
+  double rawaout = 0.0;
 
   // Prioritize turning by scaling xy_out down
   double xy_out = xyPID.output;
-  // xy_out = util::clamp(xy_out, max_slew_out, -max_slew_out);
+  xy_out = util::clamp(xy_out, max_slew_out);
+  if (print_debug) printf("xyt(%.2f, %.2f, %.2f)", odom_x_get(), odom_y_get(), odom_theta_get());
+  rawxyout = xy_out;
+  // double scale = cos(util::to_rad(current_a_odomPID.error)) / odom_turn_bias_amount;
+  double scale = 1.0 - ((1.0 - cos(util::to_rad(current_a_odomPID.error))) / odom_turn_bias_amount);  // 1 - ((1-0.7)/0.75)
   if (is_odom_turn_bias_enabled)
-    xy_out *= cos(util::to_rad(aPID.error)) / odom_turn_bias_amount;
-  double a_out = aPID.output;
-  // a_out = util::clamp(a_out, max_slew_out, -max_slew_out);
+    xy_out *= scale;
+  if (print_debug) printf("   scaled xy out by %.2f: %.2f", scale, xy_out);
+  double a_out = current_a_odomPID.output;
+  rawaout = a_out;
+  // a_out = util::clamp(a_out, max_slew_out);
 
   // Scale xy_out and a_out to max speed
   // this ensures no data is lost that would otherwise by lost in clamping
   double faster_side = fmax(fabs(xy_out), fabs(a_out));
   if (faster_side > max_slew_out) {
-    xy_out = xy_out * (max_slew_out / faster_side);
-    a_out = a_out * (max_slew_out / faster_side);
+    xy_out *= (max_slew_out / faster_side);
+    a_out *= (max_slew_out / faster_side);
   }
+
+  if (print_debug) printf("   raw xy/a(%.2f, %.2f)", rawxyout, rawaout);
+  if (print_debug) printf("   final xy/a(%.2f, %.2f)", xy_out, a_out);
 
   // Combine heading and drive
   double l_out = xy_out + a_out;
   double r_out = xy_out - a_out;
 
+  if (print_debug) printf("   raw lr(%.2f, %.2f)", l_out, r_out);
+
   // Vector scaling when combining drive and imu
   // this ensures no data is lost that would otherwise by lost in clamping
   faster_side = fmax(fabs(l_out), fabs(r_out));
   if (faster_side > max_slew_out) {
-    l_out = l_out * (max_slew_out / faster_side);
-    r_out = r_out * (max_slew_out / faster_side);
+    l_out *= (max_slew_out / faster_side);
+    r_out *= (max_slew_out / faster_side);
   }
 
+  /*
+  double forward = xy_out / max_slew_out;
+  double curve = a_out / max_slew_out;
+  double left_speed = forward + fabs(forward) * curve;
+  double right_speed = forward - fabs(forward) * curve;
+  // normalizes output
+  double fasterr_side = fmax(fabs(left_speed), fabs(right_speed));
+  if (fasterr_side > 1.0) {
+    left_speed /= fasterr_side;
+    right_speed /= fasterr_side;
+  }
+  l_out = left_speed * max_slew_out;
+  r_out = right_speed * max_slew_out;
+  */
+
+  if (print_debug) printf("   final lr(%.2f, %.2f)", l_out, r_out);
+
+  if (print_debug) printf("      a err: %.2f\n", current_a_odomPID.error);
+
   // printf("lr out (%.2f, %.2f)   fwd curveZ(%.2f, %.2f)   lr slew (%.2f, %.2f)\n", l_out, r_out, xy_out, a_out, slew_left.output(), slew_right.output());
-  // printf("max_slew_out %.2f      headingerr: %.2f\n", max_slew_out, aPID.error);
-  // printf("lr(%.2f, %.2f)   xy_raw: %.2f   xy_out: %.2f   heading_out: %.2f      max_slew_out: %.2f\n", l_out, r_out, xyPID.output, xy_out, aPID.output, max_slew_out);
-  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   aPID: %.2f     dir: %i   sgn: %i   past_target: %i    is_past_target: %i   is_past_using_xy: %i      fake_xy(%.2f, %.2f, %.2f)\n", odom_current.x, odom_current.y, odom_current.theta, xyPID.target_get(), aPID.target_get(), dir, flipped, past_target, (int)is_past_target(odom_target, odom_current), is_past_target_using_xy, fake_x, fake_y, util::to_deg(fake_angle));
-  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   aPID: %.2f   ptf:(%.2f, %.2f)\n", odom_current.x, odom_current.y, odom_current.theta, xyPID.error, aPID.error, ptf.x, ptf.y);
+  // printf("max_slew_out %.2f      headingerr: %.2f\n", max_slew_out, current_a_odomPID.error);
+  // printf("lr(%.2f, %.2f)   xy_raw: %.2f   xy_out: %.2f   heading_out: %.2f      max_slew_out: %.2f\n", l_out, r_out, xyPID.output, xy_out, current_a_odomPID.output, max_slew_out);
+  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   current_a_odomPID: %.2f     dir: %i   sgn: %i   past_target: %i    is_past_target: %i   is_past_using_xy: %i      fake_xy(%.2f, %.2f, %.2f)\n", odom_x_get(), odom_y_get(), odom_theta_get(), xyPID.target_get(), current_a_odomPID.target_get(), dir, flipped, past_target, (int)is_past_target(odom_target, odom_pose_get()), is_past_target_using_xy, fake_x, fake_y, util::to_deg(fake_angle));
+  // printf("xy(%.2f, %.2f, %.2f)   xyPID: %.2f   current_a_odomPID: %.2f   ptf:(%.2f, %.2f)\n", odom_x_get(), odom_y_get(), odom_theta_get(), xyPID.error, current_a_odomPID.error, ptf.x, ptf.y);
 
   // Set motors
   if (drive_toggle)
@@ -231,7 +266,7 @@ void Drive::boomerang_task() {
   // target.theta += current_drive_direction == REV ? 180 : 0;  // Decide if going fwd or rev
   int dir = current_drive_direction == REV ? -1 : 1;
 
-  double h = util::distance_to_point(target, odom_current) * dlead;
+  double h = util::distance_to_point(target, odom_pose_get()) * odom_boomerang_dlead_get();
   double max = max_boomerang_distance;
   h = h > max ? max : h;
   h *= dir;
@@ -239,21 +274,22 @@ void Drive::boomerang_task() {
   pose temp = util::vector_off_point(-h, pp_movements[target_index].target);
   temp.theta = target.theta;
 
-  if (util::distance_to_point(target, odom_current) < LOOK_AHEAD / 2.0) {
+  if (util::distance_to_point(target, odom_pose_get()) < odom_look_ahead_get() / 2.0) {
     temp = target;
   }
 
   if (odom_target.x != temp.x || odom_target.y != temp.y) {
-    raw_pid_odom_ptp_set({temp, pp_movements[target_index].drive_direction, pp_movements[target_index].max_xy_speed}, false);
+    bool slew_on = slew_left.enabled() || slew_right.enabled() ? true : false;
+    raw_pid_odom_ptp_set({temp, pp_movements[target_index].drive_direction, pp_movements[target_index].max_xy_speed}, slew_on);
   }
 
-  // printf("cur(%.2f, %.2f, %.2f)   tar(%.2f, %.2f, %.2f)   h %.2f  \n", odom_current.x, odom_current.y, odom_current.theta, temp.x, temp.y, temp.theta, h);
+  // printf("cur(%.2f, %.2f, %.2f)   tar(%.2f, %.2f, %.2f)   h %.2f  \n", odom_x_get(), odom_y_get(), odom_theta_get(), temp.x, temp.y, temp.theta, h);
 
   ptp_task();
 }
 
 void Drive::pp_task() {
-  if (fabs(util::distance_to_point(pp_movements[pp_index].target, odom_current)) < LOOK_AHEAD) {
+  if (fabs(util::distance_to_point(pp_movements[pp_index].target, odom_pose_get())) < odom_look_ahead_get()) {
     if (pp_index < pp_movements.size() - 1) {
       pp_index = pp_index >= pp_movements.size() - 1 ? pp_index : pp_index + 1;
       bool slew_on = slew_left.enabled() || slew_right.enabled() ? true : false;

--- a/src/EZ-Template/drive/set_pid/set_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_pid.cpp
@@ -52,7 +52,7 @@ void Drive::pid_targets_reset() {
   leftPID.target_set(0);
   rightPID.target_set(0);
   xyPID.target_set(0);
-  aPID.target_set(0);
+  current_a_odomPID.target_set(0);
   forward_drivePID.target_set(0);
   backward_drivePID.target_set(0);
   turnPID.target_set(0);

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -175,9 +175,9 @@ void Drive::pid_turn_set(pose itarget, drive_directions dir, int speed, e_angle_
   current_angle_behavior = behavior;
 
   // Calculate the point to look at
-  point_to_face = find_point_to_face(odom_current, {itarget.x, itarget.y}, current_drive_direction, true);
+  point_to_face = find_point_to_face(odom_pose_get(), {itarget.x, itarget.y}, current_drive_direction, true);
 
-  double target = util::absolute_angle_to_point(point_to_face[!ptf1_running], odom_current);  // Calculate the point for angle to face
+  double target = util::absolute_angle_to_point(point_to_face[!ptf1_running], odom_pose_get());  // Calculate the point for angle to face
 
   // Compute new turn target based on new angle
   // angle_adder = (new_turn_target_compute(target, odom_imu_start, current_angle_behavior)) - target;

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -29,7 +29,7 @@ void Drive::odom_theta_set(double a) {
 void Drive::odom_x_set(okapi::QLength p_x) { odom_x_set(p_x.convert(okapi::inch)); }
 void Drive::odom_y_set(okapi::QLength p_y) { odom_y_set(p_y.convert(okapi::inch)); }
 void Drive::odom_theta_set(okapi::QAngle p_a) { odom_theta_set(p_a.convert(okapi::degree)); }
-void Drive::odom_reset() { odom_pose_set({0, 0, 0}); }
+void Drive::odom_reset() { odom_pose_set({0.0, 0.0, 0.0}); }
 void Drive::drive_width_set(double input) {
   global_track_width = fabs(input);
   if (input != 0.0) {
@@ -120,7 +120,6 @@ void Drive::ez_tracking_task() {
   // Don't let this function run if odom is disabled
   // and make sure all the "lasts" are 0
   if (!imu_calibration_complete || !odometry_enabled) {
-    v_last = 0.0;
     h_last = 0.0;
     t_last = 0.0;
     l_last = 0.0;
@@ -129,7 +128,8 @@ void Drive::ez_tracking_task() {
   }
 
   // Decide on using a horiz tracker vs not
-  std::pair<float, float> h_cur_and_track = decide_vert_sensor(odom_back_tracker, odom_back_tracker_enabled);
+
+  std::pair<float, float> h_cur_and_track = decide_vert_sensor(odom_tracker_back != nullptr ? odom_tracker_back : odom_tracker_front, odom_tracker_back_enabled);
   float h_current = h_cur_and_track.first;
   float h_track_width = h_cur_and_track.second;
   // Calculate velocity based on horiz value
@@ -137,7 +137,7 @@ void Drive::ez_tracking_task() {
   h_last = h_current;
 
   // Decide on left ime vs left tracker
-  std::pair<float, float> l_cur_and_track = decide_vert_sensor(odom_left_tracker, odom_left_tracker_enabled, drive_sensor_left(), odom_ime_track_width_left);
+  std::pair<float, float> l_cur_and_track = decide_vert_sensor(odom_tracker_left, odom_tracker_left_enabled, drive_sensor_left(), odom_ime_track_width_left);
   float l_current = l_cur_and_track.first;
   float l_track_width = l_cur_and_track.second;
   // Calculate velocity based on left value
@@ -145,7 +145,7 @@ void Drive::ez_tracking_task() {
   l_last = l_current;
 
   // Decide on right ime vs right tracker
-  std::pair<float, float> r_cur_and_track = decide_vert_sensor(odom_right_tracker, odom_right_tracker_enabled, drive_sensor_right(), odom_ime_track_width_right);
+  std::pair<float, float> r_cur_and_track = decide_vert_sensor(odom_tracker_right, odom_tracker_right_enabled, drive_sensor_right(), odom_ime_track_width_right);
   float r_current = r_cur_and_track.first;
   float r_track_width = r_cur_and_track.second;
   // Calculate velocity based on left value
@@ -157,47 +157,51 @@ void Drive::ez_tracking_task() {
   float t_ = t_current - t_last;
   t_last = t_current;
 
-  pose h_pose = solve_xy_horiz(h_track_width, t_current, h_, t_);
+  pose h_pose_ = solve_xy_horiz(h_track_width, t_current, h_, t_);
   pose l_pose_ = solve_xy_vert(l_track_width, t_current, l_, t_);
   pose r_pose_ = solve_xy_vert(r_track_width, t_current, r_, t_);
 
   r_pose.x += r_pose_.x;
   r_pose.y += r_pose_.y;
-  r_pose.x += h_pose.x;
-  r_pose.y += h_pose.y;
+  r_pose.x += h_pose_.x;
+  r_pose.y += h_pose_.y;
 
   l_pose.x += l_pose_.x;
   l_pose.y += l_pose_.y;
-  l_pose.x += h_pose.x;
-  l_pose.y += h_pose.y;
+  l_pose.x += h_pose_.x;
+  l_pose.y += h_pose_.y;
 
+  // Track width of 0, but the delta is avg of l+r
   double avg = l_ + r_;
   if (avg != 0.0)
     avg /= 2.0;
   pose central_pose_ = solve_xy_vert(0.0, t_current, avg, t_);
   central_pose.x += central_pose_.x;
   central_pose.y += central_pose_.y;
+  central_pose.x += h_pose_.x;
+  central_pose.y += h_pose_.y;
 
   odom_current.x = central_pose.x;
   odom_current.y = central_pose.y;
-  // odom_current.x = (l_pose.x + r_pose.x) / 2.0;
-  // odom_current.y = (l_pose.y + r_pose.y) / 2.0;
 
-  /*
-  // If there is a vert tracker, use it
-  if (odom_left_tracker_enabled != odom_right_tracker_enabled) {
-    if (odom_left_tracker_enabled) {
+  // If there is a single vert tracker, use it
+  if (odom_tracker_left_enabled != odom_tracker_right_enabled) {
+    if (odom_tracker_left_enabled) {
       odom_current.x = l_pose.x;
       odom_current.y = l_pose.y;
-    } else if (odom_right_tracker_enabled) {
+    } else if (odom_tracker_right_enabled) {
       odom_current.x = r_pose.x;
       odom_current.y = r_pose.y;
     }
   }
   // If both sides have a sensor (2 vert trackers or 0 trackers), let the user pick what side
-  //  defaults to left
+  //  defaults to left tracker and central ime
   else {
-    if (odom_ime_use_left) {
+    // If using IMEs, use central pose
+    if (is_tracker == DRIVE_INTEGRATED) {
+      odom_current.x = central_pose.x;
+      odom_current.y = central_pose.y;
+    } else if (odom_use_left) {
       odom_current.x = l_pose.x;
       odom_current.y = l_pose.y;
     } else {
@@ -205,16 +209,13 @@ void Drive::ez_tracking_task() {
       odom_current.y = r_pose.y;
     }
   }
-  */
+
   odom_current.theta = drive_imu_get();
 
   // printf("odom_ime_track_width_left %f   l_ %f   r_ %f   t_current %f\n", odom_ime_track_width_left, r_, t_, t_current);
 
-  // printf("left_ (%.2f, %.2f, %.2f)", l_pose_.x, l_pose_.y, drive_imu_get());
-  // printf("   right_ (%.2f, %.2f, %.2f)\n", r_pose_.x, r_pose_.y, drive_imu_get());
-
-  // printf("left (%.2f, %.2f, %.2f)", l_pose.x, l_pose.y, drive_imu_get());
-  // printf("   right (%.2f, %.2f, %.2f)", r_pose.x, r_pose.y, drive_imu_get());
-  // printf("   current used (%.2f, %.2f, %.2f)      l delta: %.2f   r delta: %.2f\n", odom_current.x, odom_current.y, drive_imu_get(), l_, r_);
-  // printf("        lo: %.2f  ro: %.2f  tw: %.2f\n", l_track_width, r_track_width, global_track_width);
+  // printf("left (%.2f, %.2f)", l_pose.x, l_pose.y);
+  // printf("   right (%.2f, %.2f)", r_pose.x, r_pose.y);
+  // printf("   current used (%.2f, %.2f, %.2f)      l delta: %.2f   r delta: %.2f", odom_current.x, odom_current.y, odom_current.theta, l_, r_);
+  // printf("        htw: %f\n", h_track_width);
 }

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -10,16 +10,38 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 using namespace ez;
 
 // Sets and gets
-void Drive::odom_x_set(double x) { odom_current.x = x; }
-void Drive::odom_y_set(double y) { odom_current.y = y; }
-void Drive::odom_theta_set(double a) { drive_angle_set(a); }
+void Drive::odom_x_set(double x) {
+  odom_current.x = x;
+  l_pose.x = x;
+  r_pose.x = x;
+  central_pose.x = x;
+}
+void Drive::odom_y_set(double y) {
+  odom_current.y = y;
+  l_pose.y = y;
+  r_pose.y = y;
+  central_pose.y = y;
+}
+void Drive::odom_theta_set(double a) {
+  drive_angle_set(a);
+  central_pose.theta = a;
+}
 void Drive::odom_x_set(okapi::QLength p_x) { odom_x_set(p_x.convert(okapi::inch)); }
 void Drive::odom_y_set(okapi::QLength p_y) { odom_y_set(p_y.convert(okapi::inch)); }
 void Drive::odom_theta_set(okapi::QAngle p_a) { odom_theta_set(p_a.convert(okapi::degree)); }
 void Drive::odom_reset() { odom_pose_set({0, 0, 0}); }
-void Drive::drive_width_set(double input) { track_width = input; }
+void Drive::drive_width_set(double input) {
+  global_track_width = fabs(input);
+  if (input != 0.0) {
+    odom_ime_track_width_left = -(global_track_width / 2.0);
+    odom_ime_track_width_right = (global_track_width / 2.0);
+    return;
+  }
+  odom_ime_track_width_left = 0.0;
+  odom_ime_track_width_right = 0.0;
+}
 void Drive::drive_width_set(okapi::QLength p_input) { drive_width_set(p_input.convert(okapi::inch)); }
-double Drive::drive_width_get() { return track_width; }
+double Drive::drive_width_get() { return global_track_width; }
 void Drive::odom_enable(bool input) { odometry_enabled = input; }
 bool Drive::odom_enabled() { return odometry_enabled; }
 void Drive::odom_pose_set(united_pose itarget) { odom_pose_set(util::united_pose_to_pose(itarget)); }
@@ -34,76 +56,165 @@ double Drive::odom_y_get() { return odom_current.y; }
 double Drive::odom_theta_get() { return odom_current.theta; }
 pose Drive::odom_pose_get() { return odom_current; }
 
+std::pair<float, float> Drive::decide_vert_sensor(ez::tracking_wheel *tracker, bool is_tracker_enabled, float ime, float ime_track) {
+  float current = ime;
+  float track_width = ime_track;
+  if (is_tracker_enabled) {
+    current = tracker->get();
+    track_width = tracker->distance_to_center_get();
+  }
+
+  return {current, track_width};
+}
+
+ez::pose Drive::solve_xy_vert(float p_track_width, float current_t, float delta_vert, float delta_t) {
+  pose output = {0.0, 0.0, 0.0};
+
+  // Figure out how far we've actually moved
+  float local_x = delta_vert;
+  float half_delta_t = 0.0;
+  if (delta_t != 0) {
+    half_delta_t = delta_t / 2.0;
+    float i = sin(half_delta_t) * 2.0;
+    local_x = (delta_vert / delta_t - p_track_width) * i;
+  }
+
+  float alpha = current_t - half_delta_t;
+  float x = cos(alpha) * local_x;
+  float y = sin(alpha) * local_x;
+
+  // xy is calculated internally using math standard but translated to what's intuitive
+  // where going forward from 0 degrees increases Y
+  output.x = -y;
+  output.y = x;
+
+  return output;
+}
+
+ez::pose Drive::solve_xy_horiz(float p_track_width, float current_t, float delta_horiz, float delta_t) {
+  pose output = {0.0, 0.0, 0.0};
+
+  // Figure out how far we've actually moved
+  float local_y = delta_horiz;
+  float half_delta_t = 0.0;
+  if (delta_t != 0) {
+    half_delta_t = delta_t / 2.0;
+    float i = sin(half_delta_t) * 2.0;
+    local_y = (delta_horiz / delta_t + p_track_width) * i;
+  }
+
+  float alpha = current_t - half_delta_t;
+  float x = -sin(alpha) * local_y;
+  float y = cos(alpha) * local_y;
+
+  // xy is calculated internally using math standard but translated to what's intuitive
+  // where going forward from 0 degrees increases Y
+  output.x = -y;
+  output.y = x;
+
+  return output;
+}
+// pose central_pose;
 // Tracking based on https://wiki.purduesigbots.com/software/odometry
 void Drive::ez_tracking_task() {
   // Don't let this function run if odom is disabled
   // and make sure all the "lasts" are 0
   if (!imu_calibration_complete || !odometry_enabled) {
-    v_last = 0;
-    h_last = 0;
-    last_theta = 0;
+    v_last = 0.0;
+    h_last = 0.0;
+    t_last = 0.0;
+    l_last = 0.0;
+    r_last = 0.0;
     return;
   }
 
-  // Figure out what sensor to use for the vertical tracking
-  float vertical_current = 0.0;
-  float vertical_track_width = 0.0;
-  if (odom_right_tracker_enabled) {
-    vertical_current = odom_right_tracker->get();
-    vertical_track_width = odom_right_tracker->distance_to_center_get();
-  } else if (odom_left_tracker_enabled) {
-    vertical_current = odom_left_tracker->get();
-    vertical_track_width = odom_left_tracker->distance_to_center_get();
-  } else {
-    vertical_current = drive_sensor_right();
-    vertical_track_width = track_width / 2.0;
-  }
+  // Decide on using a horiz tracker vs not
+  std::pair<float, float> h_cur_and_track = decide_vert_sensor(odom_back_tracker, odom_back_tracker_enabled);
+  float h_current = h_cur_and_track.first;
+  float h_track_width = h_cur_and_track.second;
+  // Calculate velocity based on horiz value
+  float h_ = h_current - h_last;
+  h_last = h_current;
 
-  // Figure out what sensor to use for horizontal tracking
-  float horizontal_current = 0.0;
-  float horizontal_track_width = 0.0;
-  if (odom_back_tracker_enabled) {
-    horizontal_current = odom_back_tracker->get();
-    horizontal_track_width = odom_back_tracker->distance_to_center_get();
-  } else if (odom_front_tracker_enabled) {
-    horizontal_current = odom_front_tracker->get();
-    horizontal_track_width = odom_front_tracker->distance_to_center_get();
-  }
+  // Decide on left ime vs left tracker
+  std::pair<float, float> l_cur_and_track = decide_vert_sensor(odom_left_tracker, odom_left_tracker_enabled, drive_sensor_left(), odom_ime_track_width_left);
+  float l_current = l_cur_and_track.first;
+  float l_track_width = l_cur_and_track.second;
+  // Calculate velocity based on left value
+  float l_ = l_current - l_last;
+  l_last = l_current;
 
-  // Vertical sensor and velocity
-  float v_ = vertical_current - v_last;
-  v_last = vertical_current;
-
-  // Horizontal sensor and velocity
-  float c_ = horizontal_current - h_last;
-  h_last = horizontal_current;
+  // Decide on right ime vs right tracker
+  std::pair<float, float> r_cur_and_track = decide_vert_sensor(odom_right_tracker, odom_right_tracker_enabled, drive_sensor_right(), odom_ime_track_width_right);
+  float r_current = r_cur_and_track.first;
+  float r_track_width = r_cur_and_track.second;
+  // Calculate velocity based on left value
+  float r_ = r_current - r_last;
+  r_last = r_current;
 
   // Angle and velocity
-  float current_global_theta = ez::util::to_rad(drive_imu_get());
-  float theta = current_global_theta - last_theta;
-  last_theta = current_global_theta;
+  float t_current = -ez::util::to_rad(drive_imu_get());  // negative for math standard
+  float t_ = t_current - t_last;
+  t_last = t_current;
 
-  // Figure out how far we've actually moved
-  float beta = 0.0;
-  float local_y = v_;
-  float local_x = c_;
-  if (theta != 0) {
-    float v_radius = v_ / theta;
-    beta = theta / 2.0;
-    local_y = ((v_radius + vertical_track_width) * sin(beta)) * 2.0;
-    float h_radius = c_ / theta;
-    local_x = ((h_radius + horizontal_track_width) * sin(beta)) * 2.0;
+  pose h_pose = solve_xy_horiz(h_track_width, t_current, h_, t_);
+  pose l_pose_ = solve_xy_vert(l_track_width, t_current, l_, t_);
+  pose r_pose_ = solve_xy_vert(r_track_width, t_current, r_, t_);
+
+  r_pose.x += r_pose_.x;
+  r_pose.y += r_pose_.y;
+  r_pose.x += h_pose.x;
+  r_pose.y += h_pose.y;
+
+  l_pose.x += l_pose_.x;
+  l_pose.y += l_pose_.y;
+  l_pose.x += h_pose.x;
+  l_pose.y += h_pose.y;
+
+  double avg = l_ + r_;
+  if (avg != 0.0)
+    avg /= 2.0;
+  pose central_pose_ = solve_xy_vert(0.0, t_current, avg, t_);
+  central_pose.x += central_pose_.x;
+  central_pose.y += central_pose_.y;
+
+  odom_current.x = central_pose.x;
+  odom_current.y = central_pose.y;
+  // odom_current.x = (l_pose.x + r_pose.x) / 2.0;
+  // odom_current.y = (l_pose.y + r_pose.y) / 2.0;
+
+  /*
+  // If there is a vert tracker, use it
+  if (odom_left_tracker_enabled != odom_right_tracker_enabled) {
+    if (odom_left_tracker_enabled) {
+      odom_current.x = l_pose.x;
+      odom_current.y = l_pose.y;
+    } else if (odom_right_tracker_enabled) {
+      odom_current.x = r_pose.x;
+      odom_current.y = r_pose.y;
+    }
   }
-
-  float alpha = angle_rad + beta;
-
-  float x = local_x * cos(alpha);
-  x += local_y * sin(alpha);
-  float y = local_x * -sin(alpha);
-  y += local_y * cos(alpha);
-
-  odom_current.x += x;
-  odom_current.y += y;
-  angle_rad = current_global_theta;
+  // If both sides have a sensor (2 vert trackers or 0 trackers), let the user pick what side
+  //  defaults to left
+  else {
+    if (odom_ime_use_left) {
+      odom_current.x = l_pose.x;
+      odom_current.y = l_pose.y;
+    } else {
+      odom_current.x = r_pose.x;
+      odom_current.y = r_pose.y;
+    }
+  }
+  */
   odom_current.theta = drive_imu_get();
+
+  // printf("odom_ime_track_width_left %f   l_ %f   r_ %f   t_current %f\n", odom_ime_track_width_left, r_, t_, t_current);
+
+  // printf("left_ (%.2f, %.2f, %.2f)", l_pose_.x, l_pose_.y, drive_imu_get());
+  // printf("   right_ (%.2f, %.2f, %.2f)\n", r_pose_.x, r_pose_.y, drive_imu_get());
+
+  // printf("left (%.2f, %.2f, %.2f)", l_pose.x, l_pose.y, drive_imu_get());
+  // printf("   right (%.2f, %.2f, %.2f)", r_pose.x, r_pose.y, drive_imu_get());
+  // printf("   current used (%.2f, %.2f, %.2f)      l delta: %.2f   r delta: %.2f\n", odom_current.x, odom_current.y, drive_imu_get(), l_, r_);
+  // printf("        lo: %.2f  ro: %.2f  tw: %.2f\n", l_track_width, r_track_width, global_track_width);
 }

--- a/src/autons.cpp
+++ b/src/autons.cpp
@@ -20,16 +20,16 @@ void default_constants() {
   chassis.pid_heading_constants_set(11.0, 0.0, 20.0);        // Holds the robot straight while going forward without odom
   chassis.pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);     // Turn in place constants
   chassis.pid_swing_constants_set(6.0, 0.0, 65.0);           // Swing constants
-  chassis.pid_odom_angular_constants_set(5.5, 0.0, 62.5);    // Angular control for odom motions // 5.5 62.5 // 6 72.5
-  chassis.pid_odom_boomerang_constants_set(3.5, 0.0, 35.0);  // Angular control for boomerang motions // 5.7 65.0 // 5.5 62.5 // 6 72.5
+  chassis.pid_odom_angular_constants_set(5.0, 0.0, 60.0);    // Angular control for odom motions
+  chassis.pid_odom_boomerang_constants_set(3.5, 0.0, 35.0);  // Angular control for boomerang motions
 
   // Exit conditions
   // https://ez-robotics.github.io/EZ-Template/tutorials/tuning_exit_conditions
   chassis.pid_turn_exit_condition_set(80_ms, 3_deg, 250_ms, 7_deg, 500_ms, 500_ms);
   chassis.pid_swing_exit_condition_set(80_ms, 3_deg, 250_ms, 7_deg, 500_ms, 500_ms);
   chassis.pid_drive_exit_condition_set(80_ms, 1_in, 250_ms, 3_in, 500_ms, 500_ms);
-  chassis.pid_odom_turn_exit_condition_set(80_ms, 3_deg, 250_ms, 7_deg, 500_ms, 750_ms);
-  chassis.pid_odom_drive_exit_condition_set(80_ms, 1_in, 250_ms, 3_in, 500_ms, 750_ms);
+  chassis.pid_odom_turn_exit_condition_set(90_ms, 3_deg, 250_ms, 7_deg, 500_ms, 750_ms);
+  chassis.pid_odom_drive_exit_condition_set(90_ms, 1_in, 250_ms, 3_in, 500_ms, 750_ms);
   chassis.pid_turn_chain_constant_set(3_deg);
   chassis.pid_swing_chain_constant_set(5_deg);
   chassis.pid_drive_chain_constant_set(3_in);

--- a/src/autons.cpp
+++ b/src/autons.cpp
@@ -16,10 +16,12 @@ const int SWING_SPEED = 110;
 void default_constants() {
   // P, I, D, and Start I
   // https://ez-robotics.github.io/EZ-Template/tutorials/tuning_constants
-  chassis.pid_heading_constants_set(7, 0, 45);
-  chassis.pid_drive_constants_set(20, 0, 100);
-  chassis.pid_turn_constants_set(3, 0.05, 20, 15);
-  chassis.pid_swing_constants_set(6, 0, 65);
+  chassis.pid_drive_constants_set(20.0, 0.0, 100.0);         // Fwd/rev constants, used for odom and non odom motions
+  chassis.pid_heading_constants_set(11.0, 0.0, 20.0);        // Holds the robot straight while going forward without odom
+  chassis.pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);     // Turn in place constants
+  chassis.pid_swing_constants_set(6.0, 0.0, 65.0);           // Swing constants
+  chassis.pid_odom_angular_constants_set(5.5, 0.0, 62.5);    // Angular control for odom motions // 5.5 62.5 // 6 72.5
+  chassis.pid_odom_boomerang_constants_set(3.5, 0.0, 35.0);  // Angular control for boomerang motions // 5.7 65.0 // 5.5 62.5 // 6 72.5
 
   // Exit conditions
   // https://ez-robotics.github.io/EZ-Template/tutorials/tuning_exit_conditions
@@ -39,15 +41,14 @@ void default_constants() {
   chassis.slew_swing_constants_set(3_in, 80);
 
   // The amount that turns are prioritized over driving in odom motions
-  // - this is fully disabled for straight motions
-  // - if you have tracking wheels, you can run this lower
-  chassis.odom_turn_bias_set(1.375);
+  // - if you have tracking wheels, you can run this higher.  1 is the max
+  chassis.odom_turn_bias_set(0.5);
 
-  // This sets the maximum distance away from target that the carrot point can be
-  chassis.odom_boomerang_distance_set(12_in);
+  chassis.odom_look_ahead_set(10_in);          // This is how far ahead in the path the robot looks at
+  chassis.odom_boomerang_distance_set(16_in);  // This sets the maximum distance away from target that the carrot point can be
+  chassis.odom_boomerang_dlead_set(0.625);     // This handles how aggressive the end of boomerang motions are
 
-  // Defaults the turn behavior to always go the shortest way
-  chassis.pid_angle_behavior_set(ez::shortest);
+  chassis.pid_angle_behavior_set(ez::shortest);  // Changes the default behavior for turning, this defaults it to the shortest path there
 }
 
 ///

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,6 @@ void initialize() {
 
   pros::delay(500);  // Stop the user from doing anything while legacy ports configure
 
-  chassis.drive_width_set(12.0_in);
   // Are you using tracking wheels?  Comment out which ones you're using here!
   // chassis.odom_tracker_right_set(&right_tracker);
   // chassis.odom_tracker_left_set(&left_tracker);
@@ -115,11 +114,12 @@ void competition_initialize() {
  * from where it left off.
  */
 void autonomous() {
-  chassis.pid_targets_reset();                // Resets PID targets to 0
-  chassis.drive_imu_reset();                  // Reset gyro position to 0
-  chassis.drive_sensor_reset();               // Reset drive sensors to 0
-  chassis.drive_brake_set(MOTOR_BRAKE_HOLD);  // Set motors to hold.  This helps autonomous consistency
-  chassis.odom_pose_set({0_in, 0_in, 0_deg});
+  chassis.pid_targets_reset();                 // Resets PID targets to 0
+  chassis.drive_imu_reset();                   // Reset gyro position to 0
+  chassis.drive_sensor_reset();                // Reset drive sensors to 0
+  chassis.odom_pose_set({0_in, 0_in, 0_deg});  // Reset the current position to 0
+  chassis.drive_brake_set(MOTOR_BRAKE_HOLD);   // Set motors to hold.  This helps autonomous consistency
+  chassis.drive_width_set(12.0_in);
 
   int speed = 110;
 
@@ -166,7 +166,7 @@ void ez_template_etxras() {
     }
 
     // Blank pages for Odom Debugging
-    if (chassis.odom_enabled() && !chassis.pid_tuner_enabled()) {
+    if (chassis.odom_enabled()) {
       // This is Blank Page 1, it will display X, Y, and Angle
       if (ez::as::page_blank_is_on(0)) {
         screen_print("x: " + std::to_string(chassis.odom_x_get()) +
@@ -177,23 +177,23 @@ void ez_template_etxras() {
       // This is Blank Page 2, it will display every tracking wheel.
       // Make sure the tracking wheels read POSITIVE going forwards or right.
       else if (ez::as::page_blank_is_on(1)) {
-        if (chassis.odom_left_tracker != nullptr)
-          screen_print("left tracker: " + std::to_string(chassis.odom_left_tracker->get()), 1);
+        if (chassis.odom_tracker_left != nullptr)
+          screen_print("left tracker: " + std::to_string(chassis.odom_tracker_left->get()), 1);
         else
           screen_print("no left tracker", 1);
 
-        if (chassis.odom_right_tracker != nullptr)
-          screen_print("right tracker: " + std::to_string(chassis.odom_right_tracker->get()), 2);
+        if (chassis.odom_tracker_right != nullptr)
+          screen_print("right tracker: " + std::to_string(chassis.odom_tracker_right->get()), 2);
         else
           screen_print("no right tracker", 2);
 
-        if (chassis.odom_back_tracker != nullptr)
-          screen_print("back tracker: " + std::to_string(chassis.odom_back_tracker->get()), 3);
+        if (chassis.odom_tracker_back != nullptr)
+          screen_print("back tracker: " + std::to_string(chassis.odom_tracker_back->get()), 3);
         else
           screen_print("no back tracker", 3);
 
-        if (chassis.odom_front_tracker != nullptr)
-          screen_print("front tracker: " + std::to_string(chassis.odom_front_tracker->get()), 4);
+        if (chassis.odom_tracker_front != nullptr)
+          screen_print("front tracker: " + std::to_string(chassis.odom_tracker_front->get()), 4);
         else
           screen_print("no front tracker", 4);
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ ez::Drive chassis(
     {-5, -6, -7, -8},  // Left Chassis Ports (negative port will reverse it!)
     {11, 15, 16, 17},  // Right Chassis Ports (negative port will reverse it!)
 
-    21,      // IMU port
+    21,      // IMU Port
     4.125,   // Wheel Diameter (Remember, 4" wheels without screw holes are actually 4.125!)
     420.0);  // Wheel RPM = cartridge * (motor gear / wheel gear)
 
@@ -117,25 +117,32 @@ void autonomous() {
   chassis.pid_targets_reset();                 // Resets PID targets to 0
   chassis.drive_imu_reset();                   // Reset gyro position to 0
   chassis.drive_sensor_reset();                // Reset drive sensors to 0
-  chassis.odom_pose_set({0_in, 0_in, 0_deg});  // Reset the current position to 0
+  chassis.odom_pose_set({0_in, 0_in, 0_deg});  // Set the current position, you can start at a specific position with this
   chassis.drive_brake_set(MOTOR_BRAKE_HOLD);   // Set motors to hold.  This helps autonomous consistency
-  chassis.drive_width_set(12.0_in);
+  chassis.drive_width_set(12.0_in);            // You can measure this with a tape measure
 
-  int speed = 110;
-
-  // chassis.pid_odom_set({{0_in, 24_in, 90_deg}, fwd, speed});
-
-  chassis.pid_odom_set({{{0_in, 24_in}, fwd, speed},
-                        {{24_in, 24_in}, fwd, speed}},
+  // Drive to 0, 24
+  chassis.pid_odom_set({{0_in, 24_in}, fwd, 110},
                        true);
-  // chassis.pid_odom_set({{{16_in, 16_in}, fwd, speed}}, true);
   chassis.pid_wait();
-  pros::delay(250);
 
-  // chassis.pid_odom_set({{24_in, 24_in, 90_deg}, fwd, speed}, true);
-  // chassis.pid_wait();
-  // pros::delay(250);
+  // Turn to face 24, 24
+  chassis.pid_turn_set({24_in, 24_in}, fwd, 110,
+                       true);
+  chassis.pid_wait();
 
+  // Drive to 24, 24
+  chassis.pid_odom_set({{24_in, 24_in}, fwd, 110},
+                       true);
+  chassis.pid_wait();
+
+  // Drive backwards through 0, 24 and stop at 0, 0
+  chassis.pid_odom_set({{{0_in, 24_in}, rev, 110},
+                        {{0_in, 0_in}, rev, 110}},
+                       true);
+  chassis.pid_wait();
+
+  // Uncomment this to use the auton selector
   // ez::as::auton_selector.selected_auton_call();  // Calls selected auton from autonomous selector
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ ez::Drive chassis(
     pros::IMU(21),  // IMU port
     4.125,          // Wheel Diameter (Remember, 4" wheels without screw holes are actually 4.125!)
     420.0,          // Wheel RPM = cartridge * (motor gear / wheel gear)
-    11.0);          // Width of your powered wheels.  Measure this with a tape measure, center-to-center
+    12.0);          // Width of your powered wheels.  Measure this with a tape measure, center-to-center
 */
 ez::Drive chassis(
     // These are your drive motors, the first motor is used for sensing!
@@ -45,6 +45,7 @@ void initialize() {
 
   pros::delay(500);  // Stop the user from doing anything while legacy ports configure
 
+  chassis.drive_width_set(12.0_in);
   // Are you using tracking wheels?  Comment out which ones you're using here!
   // chassis.odom_tracker_right_set(&right_tracker);
   // chassis.odom_tracker_left_set(&left_tracker);
@@ -119,15 +120,21 @@ void autonomous() {
   chassis.drive_sensor_reset();               // Reset drive sensors to 0
   chassis.drive_brake_set(MOTOR_BRAKE_HOLD);  // Set motors to hold.  This helps autonomous consistency
   chassis.odom_pose_set({0_in, 0_in, 0_deg});
-  chassis.drive_width_set(11_in);  // Measure this with a tape measure
 
-  chassis.pid_odom_set({{{0_in, 16_in}, fwd, 110},
-                        {{16_in, 16_in}, fwd, 110}},
+  int speed = 110;
+
+  // chassis.pid_odom_set({{0_in, 24_in, 90_deg}, fwd, speed});
+
+  chassis.pid_odom_set({{{0_in, 24_in}, fwd, speed},
+                        {{24_in, 24_in}, fwd, speed}},
                        true);
+  // chassis.pid_odom_set({{{16_in, 16_in}, fwd, speed}}, true);
   chassis.pid_wait();
+  pros::delay(250);
 
-  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, rev, 110}, true);
-  chassis.pid_wait();
+  // chassis.pid_odom_set({{24_in, 24_in, 90_deg}, fwd, speed}, true);
+  // chassis.pid_wait();
+  // pros::delay(250);
 
   // ez::as::auton_selector.selected_auton_call();  // Calls selected auton from autonomous selector
 }
@@ -159,7 +166,7 @@ void ez_template_etxras() {
     }
 
     // Blank pages for Odom Debugging
-    if (chassis.odom_enabled()) {
+    if (chassis.odom_enabled() && !chassis.pid_tuner_enabled()) {
       // This is Blank Page 1, it will display X, Y, and Angle
       if (ez::as::page_blank_is_on(0)) {
         screen_print("x: " + std::to_string(chassis.odom_x_get()) +


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Restructured tracking entirely, along with retuning movements due to tracking reading differently now.  There is slight differences still in switching from trackers to no trackers, but I think that will always be the case to some extent.  This was always able to be tuned away with offsets.

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Trackers didn't work on beta 4 unless they were on the right side of the drive, and horizontal trackers didn't work at all

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#177 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Ran through multiple autonomous routines, tested with and without trackers, to ensure consistent behavior across everything.  

- [ ] test item