### PR TITLE
Can now relative drive after odom motions

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -85,7 +85,7 @@ void Drive::pid_odom_set(double target, int speed) {
 }
 void Drive::pid_odom_set(double target, int speed, bool slew_on) {
   drive_directions fwd_or_rev = util::sgn(target) >= 0 ? fwd : rev;
-  pose target_pose = util::vector_off_point(target, odom_pose_get());
+  pose target_pose = util::vector_off_point(target, {odom_x_get(), odom_y_get(), headingPID.target_get()});
   odom path = {target_pose, fwd_or_rev, speed};
 
   xyPID.timers_reset();
@@ -390,6 +390,8 @@ void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on) {
   if (current_slew_on && imovement.max_xy_speed > pid_speed_max_get() && slew_odom_reenabled()) {
     slew_will_enable_later = true;
   }
+  target = new_turn_target_compute(target, odom_imu_start, current_angle_behavior);
+  headingPID.target_set(target);
 
   // Set targets
   odom_target.x = imovement.target.x;


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Update heading target in odom motions, use heading target in `pid_odom_set` with `pid_drive_set` syntax

## Motivation:
<!-- Small explanation of why these changes need to be made -->

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#195 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Make some autos that use relative motions throughout odom motions and ensure they work as expected
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 83c68f1e22d7473068374918719c80f57250d648 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12089362523)
- via manual download: [EZ-Template@3.2.0-beta.6+a0fb3d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255092200.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.6+a0fb3d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255092200.zip;
pros c fetch EZ-Template@3.2.0-beta.6+a0fb3d.zip;
pros c apply EZ-Template@3.2.0-beta.6+a0fb3d;
rm EZ-Template@3.2.0-beta.6+a0fb3d.zip;
```