### PR TITLE
Can now flip angle #161

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -602,7 +602,7 @@ class Drive {
    * \param flip
    *        true means left is positive x, false means right is positive x
    */
-  void odom_x_direction_flip(bool flip = true);
+  void odom_x_flip(bool flip = true);
 
   /**
    * Checks if x axis is flipped.  True means left is positive x, false means right is positive x
@@ -613,14 +613,27 @@ class Drive {
    * Flips the Y axis
    *
    * \param flip
-   *        true means down is positive Y, false means down is positive Y
+   *        true means down is positive Y, false means up is positive Y
    */
-  void odom_y_direction_flip(bool flip = true);
+  void odom_y_flip(bool flip = true);
 
   /**
-   * Checks if x axis is flipped.  True means down is positive Y, false means down is positive Y
+   * Checks if y axis is flipped.  True means down is positive Y, false means up is positive Y
    */
   bool odom_y_direction_get();
+
+  /**
+   * Flips the rotation axis
+   *
+   * \param flip
+   *        true means clockwise is positive, false means counterclockwise is positive
+   */
+  void odom_theta_flip(bool flip = true);
+
+  /**
+   * Checks if the rotation axis is flipped.  True means clockwise is positive, false means counterclockwise is positive
+   */
+  bool odom_theta_direction_get();
 
   /**
    * Sets a new dlead.  Dlead is a proportional value of how much to make the robot curve during boomerang motions.
@@ -3141,6 +3154,8 @@ class Drive {
   pose turn_to_point_target = {0.0, 0.0, 0.0};
   bool y_flipped = false;
   bool x_flipped = false;
+  bool theta_flipped = false;
+  double flip_angle_target(double target);
   double odom_imu_start = 0.0;
   int past_target = 0;
   double SPACING = 0.5;

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -17,10 +17,13 @@ ez::e_angle_behavior Drive::pid_odom_behavior_get() { return default_odom_type; 
 pose Drive::flip_pose(pose input) {
   int flip_x = x_flipped ? -1 : 1;
   int flip_y = y_flipped ? -1 : 1;
+  int flip_a = theta_flipped ? -1 : 1;
 
   pose new_pose = input;
   new_pose.x *= flip_x;
   new_pose.y *= flip_y;
+  if (new_pose.theta != ANGLE_NOT_SET)
+    new_pose.theta = flip_angle_target(new_pose.theta);
 
   return new_pose;
 }
@@ -46,10 +49,12 @@ void Drive::pid_odom_angular_constants_set(double p, double i, double d, double 
 void Drive::pid_odom_boomerang_constants_set(double p, double i, double d, double p_start_i) {
   boomerangPID.constants_set(p, i, d, p_start_i);
 }
-void Drive::odom_x_direction_flip(bool flip) { x_flipped = flip; }
+void Drive::odom_x_flip(bool flip) { x_flipped = flip; }
 bool Drive::odom_x_direction_get() { return x_flipped; }
-void Drive::odom_y_direction_flip(bool flip) { y_flipped = flip; }
+void Drive::odom_y_flip(bool flip) { y_flipped = flip; }
 bool Drive::odom_y_direction_get() { return y_flipped; }
+void Drive::odom_theta_flip(bool flip) { theta_flipped = flip; }
+bool Drive::odom_theta_direction_get() { return theta_flipped; }
 void Drive::odom_boomerang_dlead_set(double input) { dlead = input; }
 double Drive::odom_boomerang_dlead_get() { return dlead; }
 void Drive::odom_boomerang_distance_set(double distance) { max_boomerang_distance = distance; }

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -280,6 +280,7 @@ void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_s
   current_angle_behavior = behavior;
 
   // Compute new turn target based on new angle
+  target = flip_angle_target(target);
   target = new_turn_target_compute(target, drive_imu_get(), current_angle_behavior);
 
   // Print targets

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -30,6 +30,13 @@ ez::e_angle_behavior Drive::pid_turn_behavior_get() { return default_turn_type; 
 void Drive::slew_turn_set(bool slew_on) { global_turn_slew_enabled = slew_on; }
 bool Drive::slew_turn_get() { return global_turn_slew_enabled; }
 
+double Drive::flip_angle_target(double target) {
+  int flip_theta = theta_flipped ? -1 : 1;
+  double new_target = target;
+  new_target *= flip_theta;
+  return new_target;
+}
+
 /////
 // Set turn PID basic wrappers
 /////
@@ -116,6 +123,7 @@ void Drive::pid_turn_set(double target, int speed, e_angle_behavior behavior, bo
   current_angle_behavior = behavior;
 
   // Compute new turn target based on new angle
+  target = flip_angle_target(target);
   target = new_turn_target_compute(target, drive_imu_get(), current_angle_behavior);
 
   // Print targets


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Can now flip angle with `odom_theta_flip`
This does cause breaking changes, as `odom_x_direction_flip` was renamed to `odom_x_flip` and `odom_y_direction_flip` was renamed to `odom_y_flip`.  The getters still have `direction` in them

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Mirrored field problem

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#161

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Run this with and without `odom_theta_flip`
```cpp
  chassis.odom_theta_flip();

  chassis.pid_odom_set({{0_in, 18_in, 45_deg}, fwd, 110},
                       true);
  chassis.pid_wait();

  chassis.pid_turn_set(90_deg, 110, true);
  chassis.pid_wait();
  ```
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 0da1d10f4008206a29dca2b025efde6ff81e1219 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12090088041)
- via manual download: [EZ-Template@3.2.0-beta.6+71e6e8.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255278079.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.6+71e6e8.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255278079.zip;
pros c fetch EZ-Template@3.2.0-beta.6+71e6e8.zip;
pros c apply EZ-Template@3.2.0-beta.6+71e6e8;
rm EZ-Template@3.2.0-beta.6+71e6e8.zip;
```