### PR TITLE
Added units to wait_until (#199)

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -2351,12 +2351,28 @@ class Drive {
   void pid_wait_until_point(pose target);
 
   /**
+   * Lock the code in a while loop until this point has been passed, with okapi units.
+   *
+   * \param target
+   *        {x, y}  a pose with units for the robot to pass through before the while loop is released
+   */
+  void pid_wait_until_point(united_pose target);
+
+  /**
    * Lock the code in a while loop until this point has been passed.  Wrapper for pid_wait_until_point
    *
    * \param target
    *        {x, y}  a pose for the robot to pass through before the while loop is released
    */
   void pid_wait_until(pose target);
+
+  /**
+   * Lock the code in a while loop until this point has been passed, with okapi units.  Wrapper for pid_wait_until_point
+   *
+   * \param target
+   *        {x, y}  a pose with units for the robot to pass through before the while loop is released
+   */
+  void pid_wait_until(united_pose target);
 
   /**
    * Autonomous interference detection.  Returns true when interfered, and false when nothing happened.

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -386,9 +386,9 @@ void Drive::pid_wait_until_point(pose target) {
   }
 }
 
-void Drive::pid_wait_until(pose target) {
-  pid_wait_until_point(target);
-}
+void Drive::pid_wait_until_point(united_pose target) { pid_wait_until_point(util::united_pose_to_pose(target)); }
+void Drive::pid_wait_until(pose target) { pid_wait_until_point(target); }
+void Drive::pid_wait_until(united_pose target) { pid_wait_until_point(target); }
 
 // wait for pp
 void Drive::pid_wait_until_index(int index) {


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Add units to `pid_wait_until({0_in, 6_in});`

## Motivation:
<!-- Small explanation of why these changes need to be made -->

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#199

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Run this and made sure pid wait prints `0, 6`.
```cpp
  chassis.pid_odom_set({{0, 18}, fwd, 110});
  chassis.pid_wait_until({0_in, 6_in});
  chassis.pid_wait();
```


<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a489598c0d6624b583a363d95f21e260a2405f67 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12090552990)
- via manual download: [EZ-Template@3.2.0-beta.6+684d93.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255391388.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.6+684d93.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255391388.zip;
pros c fetch EZ-Template@3.2.0-beta.6+684d93.zip;
pros c apply EZ-Template@3.2.0-beta.6+684d93;
rm EZ-Template@3.2.0-beta.6+684d93.zip;
```