### PR TITLE
Added `pid_wait_until_index_started` (#198)

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -2343,12 +2343,20 @@ class Drive {
   void pid_wait_until_index(int index);
 
   /**
-   * Lock the code in a while loop until this point has been passed.
+   * Lock the code in a while loop until this point becomes the target
    *
-   * \param target
-   *        {x, y}  a pose for the robot to pass through before the while loop is released
+   * \param index
+   *        index of your input points, 0 is the first point in the index.
    */
-  void pid_wait_until_point(pose target);
+  void pid_wait_until_index_started(int index);
+
+      /**
+       * Lock the code in a while loop until this point has been passed.
+       *
+       * \param target
+       *        {x, y}  a pose for the robot to pass through before the while loop is released
+       */
+      void pid_wait_until_point(pose target);
 
   /**
    * Lock the code in a while loop until this point has been passed.  Wrapper for pid_wait_until_point

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -391,7 +391,7 @@ void Drive::pid_wait_until(pose target) {
 }
 
 // wait for pp
-void Drive::pid_wait_until_index(int index) {
+void Drive::pid_wait_until_index_started(int index) {
   // Let the PID run at least 1 iteration
   pros::delay(util::DELAY_TIME);
 
@@ -418,8 +418,13 @@ void Drive::pid_wait_until_index(int index) {
 
     pros::delay(util::DELAY_TIME);
   }
+}
 
-  pid_wait_until_point(pp_movements[injected_pp_index[index]].target);
+void Drive::pid_wait_until_index(int index) {
+  pid_wait_until_index_started(index);
+  index += 1;
+  pose target = pp_movements[injected_pp_index[index]].target;
+  pid_wait_until_point(target);
 }
 
 // Pid wait, but quickly :)


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Added `pid_wait_until_index_started()` which triggers once the index becomes the target

## Motivation:
<!-- Small explanation of why these changes need to be made -->

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#198 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Run this and make sure the pid wait prints 12, 24
```cpp
chassis.pid_odom_set({{{0_in, 24_in}, fwd, 110},
                      {{12_in, 24_in}, rev, 110},
                      {{24_in, 24_in}, rev, 110}},
                     true);
chassis.pid_wait_until_index(1);  // Waits until the robot passes 12, 24
Intake.move(127);
chassis.pid_wait();
```

Run this and make sure the pid wait prints something closer to 2, 24
```cpp
chassis.pid_odom_set({{{0_in, 24_in}, fwd, 110},
                      {{12_in, 24_in}, rev, 110},
                      {{24_in, 24_in}, rev, 110}},
                     true);
chassis.pid_wait_until_index_started(1);  // Waits until the robot passes 12, 24
Intake.move(127);
chassis.pid_wait();
```

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: e660c88fa966863ac43aa1e9b6c0951ad0cda79d -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12090575438)
- via manual download: [EZ-Template@3.2.0-beta.6+297f45.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255396226.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.6+297f45.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255396226.zip;
pros c fetch EZ-Template@3.2.0-beta.6+297f45.zip;
pros c apply EZ-Template@3.2.0-beta.6+297f45;
rm EZ-Template@3.2.0-beta.6+297f45.zip;
```