### PR TITLE
Path smoothing doesn't override lookahead #202

### DIFF
--- a/src/EZ-Template/drive/purepursuit_math.cpp
+++ b/src/EZ-Template/drive/purepursuit_math.cpp
@@ -190,9 +190,9 @@ std::vector<odom> Drive::smooth_path(std::vector<odom> ipath, double weight_smoo
 
     bool dont_touch_this_point = false;
 
-    // A one time flag to stop points from being injected for LOOK_AHEAD from current
+    // A one time flag to stop points from being smoothed for LOOK_AHEAD from current
     // https://github.com/EZ-Robotics/EZ-Template/issues/152
-    if (util::distance_to_point(ipath[i].target, ipath[0].target) >= odom_look_ahead_get())
+    if (util::distance_to_point(ipath[i].target, ipath[0].target) > odom_look_ahead_get() && !allow_injecting)
       allow_injecting = true;
 
     // if (t <= odom_look_ahead_get() / SPACING && (prev_point_angle_not_set || t != 0)))


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Path smothing doesn't force points into look ahead of the robot

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Complies with #152

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#202 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Run this and ensure there are no points within look ahead, by default this is 10in.  
```cpp
  chassis.pid_odom_set({{{0_in, 6_in}, fwd, 110},
                        {{0_in, 12_in}, fwd, 110},
                        {{0_in, 24_in}, fwd, 110}},
                       true);
  chassis.pid_wait();
```
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 6108f86a7902dd84063ee02e4aff95def6dca559 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12090837022)
- via manual download: [EZ-Template@3.2.0-beta.6+e3d7a9.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255457401.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.6+e3d7a9.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2255457401.zip;
pros c fetch EZ-Template@3.2.0-beta.6+e3d7a9.zip;
pros c apply EZ-Template@3.2.0-beta.6+e3d7a9;
rm EZ-Template@3.2.0-beta.6+e3d7a9.zip;
```