### PR TITLE
Drive isn't slow in opcontrol

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -338,7 +338,7 @@ class Drive {
   /**
    * Sets current mode of drive.
    */
-  void drive_mode_set(e_mode p_mode);
+  void drive_mode_set(e_mode p_mode, bool stop_drive = true);
 
   /**
    * Returns current mode of drive.

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -267,7 +267,7 @@ void Drive::private_drive_set(int left, int right) {
 }
 
 void Drive::drive_set(int left, int right) {
-  drive_mode_set(DISABLE);
+  drive_mode_set(DISABLE, false);
   private_drive_set(left, right);
 }
 

--- a/src/EZ-Template/drive/set_pid/set_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_pid.cpp
@@ -61,9 +61,9 @@ void Drive::pid_targets_reset() {
   backward_swingPID.target_set(0);
 }
 
-void Drive::drive_mode_set(e_mode p_mode) {
+void Drive::drive_mode_set(e_mode p_mode, bool stop_drive) {
   mode = p_mode;
-  if (mode == DISABLE)
+  if (mode == DISABLE && stop_drive)
     private_drive_set(0, 0);
 }
 e_mode Drive::drive_mode_get() { return mode; }


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->

## Motivation:
<!-- Small explanation of why these changes need to be made -->

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#157 caused #182 to exist

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Run driver and auto at max speed back to back and ensure they are the same speed

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 6735e9484f87f4bc5865605cfdf0323af1204da4 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12112849350)
- via manual download: [EZ-Template@3.2.0-beta.7+3d524a.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2259592216.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.7+3d524a.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2259592216.zip;
pros c fetch EZ-Template@3.2.0-beta.7+3d524a.zip;
pros c apply EZ-Template@3.2.0-beta.7+3d524a;
rm EZ-Template@3.2.0-beta.7+3d524a.zip;
```