### PR TITLE
Simplified PID tuner

### DIFF
--- a/include/EZ-Template/PID.hpp
+++ b/include/EZ-Template/PID.hpp
@@ -123,6 +123,11 @@ class PID {
   Constants constants_get();
 
   /**
+   * Returns true if PID constants are set, returns false if they're all 0
+   */
+  bool constants_set_check();
+
+  /**
    * Resets all variables to 0.  This does not reset constants.
    */
   void variables_reset();

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -110,13 +110,15 @@ class Drive {
    */
   PID headingPID;
   PID turnPID;
-  PID forward_drivePID;
   PID leftPID;
   PID rightPID;
+  PID forward_drivePID;
   PID backward_drivePID;
+  PID fwd_rev_drivePID;
   PID swingPID;
   PID forward_swingPID;
   PID backward_swingPID;
+  PID fwd_rev_swingPID;
   PID xyPID;
   PID current_a_odomPID;
   PID boomerangPID;
@@ -2363,13 +2365,13 @@ class Drive {
    */
   void pid_wait_until_index_started(int index);
 
-      /**
-       * Lock the code in a while loop until this point has been passed.
-       *
-       * \param target
-       *        {x, y}  a pose for the robot to pass through before the while loop is released
-       */
-      void pid_wait_until_point(pose target);
+  /**
+   * Lock the code in a while loop until this point has been passed.
+   *
+   * \param target
+   *        {x, y}  a pose for the robot to pass through before the while loop is released
+   */
+  void pid_wait_until_point(pose target);
 
   /**
    * Lock the code in a while loop until this point has been passed, with okapi units.
@@ -3098,14 +3100,12 @@ class Drive {
    * Vector used for PID Tuner
    */
   std::vector<const_and_name> pid_tuner_pids = {
-      {"Drive Forward PID Constants", &forward_drivePID.constants},
-      {"Drive Backward PID Constants", &backward_drivePID.constants},
+      {"Drive PID Constants", &fwd_rev_drivePID.constants},
       {"Odom Angular PID Constants", &odom_angularPID.constants},
       {"Boomerang Angular PID Constants", &boomerangPID.constants},
       {"Heading PID Constants", &headingPID.constants},
       {"Turn PID Constants", &turnPID.constants},
-      {"Swing Forward PID Constants", &forward_swingPID.constants},
-      {"Swing Backward PID Constants", &backward_swingPID.constants}};
+      {"Swing PID Constants", &fwd_rev_swingPID.constants}};
 
   /**
    * Sets the max speed for user control

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3091,13 +3091,27 @@ class Drive {
    */
   double pid_tuner_increment_start_i_get();
 
+  /**
+   * Enables the full PID tuner with unique fwd/rev constants
+   *
+   * \param enable
+   *        bool, true will enable the full PID tuner, false will use the simplified PID tuner
+   */
+  void pid_tuner_full_enable(bool enable);
+
+  /**
+   * Returns if the full PID tuner with unique fwd/rev constants is enabled.
+   * True means the full PID tuner is enabled, false means the simplified PID tuner is enabled.
+   */
+  bool pid_tuner_full_enabled();
+
   struct const_and_name {
     std::string name = "";
     PID::Constants* consts;
   };
 
   /**
-   * Vector used for PID Tuner
+   * Vector used for a simplified PID Tuner
    */
   std::vector<const_and_name> pid_tuner_pids = {
       {"Drive PID Constants", &fwd_rev_drivePID.constants},
@@ -3106,6 +3120,19 @@ class Drive {
       {"Heading PID Constants", &headingPID.constants},
       {"Turn PID Constants", &turnPID.constants},
       {"Swing PID Constants", &fwd_rev_swingPID.constants}};
+
+  /**
+   * Vector used for the full PID Tuner
+   */
+  std::vector<const_and_name> pid_tuner_full_pids = {
+      {"Drive Forward PID Constants", &forward_drivePID.constants},
+      {"Drive Backward PID Constants", &backward_drivePID.constants},
+      {"Odom Angular PID Constants", &odom_angularPID.constants},
+      {"Boomerang Angular PID Constants", &boomerangPID.constants},
+      {"Heading PID Constants", &headingPID.constants},
+      {"Turn PID Constants", &turnPID.constants},
+      {"Swing Forward PID Constants", &forward_swingPID.constants},
+      {"Swing Backward PID Constants", &backward_swingPID.constants}};
 
   /**
    * Sets the max speed for user control
@@ -3138,6 +3165,8 @@ class Drive {
   double odom_ime_track_width_right = 0.0;
 
  private:
+  bool is_full_pid_tuner_enabled = false;
+  std::vector<const_and_name>* used_pid_tuner_pids;
   double opcontrol_speed_max = 127.0;
   bool arcade_vector_scaling = false;
   // odom privates

--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -41,6 +41,12 @@ void PID::constants_set(double p, double i, double d, double p_start_i) {
   constants.start_i = p_start_i;
 }
 
+bool PID::constants_set_check() {
+  if (constants.kp == 0.0 && constants.ki == 0.0 && constants.kd == 0.0 && constants.start_i == 0.0)
+    return false;
+  return true;
+}
+
 // Set exit condition timeouts
 void PID::exit_condition_set(int p_small_exit_time, double p_small_error, int p_big_exit_time, double p_big_error, int p_velocity_exit_time, int p_mA_timeout) {
   exit.small_exit_time = p_small_exit_time;

--- a/src/EZ-Template/drive/pid_tuner.cpp
+++ b/src/EZ-Template/drive/pid_tuner.cpp
@@ -113,15 +113,23 @@ void Drive::pid_tuner_value_modify(float p, float i, float d, float start) {
   switch (row) {
     case 0:
       pid_tuner_pids[column].consts->kp += p;
+      if (pid_tuner_pids[column].consts->kp < 0.0)
+        pid_tuner_pids[column].consts->kp = 0.0;
       break;
     case 1:
       pid_tuner_pids[column].consts->ki += i;
+      if (pid_tuner_pids[column].consts->ki < 0.0)
+        pid_tuner_pids[column].consts->ki = 0.0;
       break;
     case 2:
       pid_tuner_pids[column].consts->kd += d;
+      if (pid_tuner_pids[column].consts->kd < 0.0)
+        pid_tuner_pids[column].consts->kd = 0.0;
       break;
     case 3:
       pid_tuner_pids[column].consts->start_i += start;
+      if (pid_tuner_pids[column].consts->start_i < 0.0)
+        pid_tuner_pids[column].consts->start_i = 0.0;
       break;
     default:
       break;


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
PID tuner now defaults to having 1 set of constants for fwd/rev drives and swings.  This can be switched over with `pid_tuner_full_enable(true);` and the PID tuner will have unique constants for fwd/rev drives and swings.  

## Motivation:
<!-- Small explanation of why these changes need to be made -->
This makes it easier to tune for a majority of teams who don't need unique fwd/rev constants.

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#205 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a4f4e430b82619e0b639724a0f5ab89057541064 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12129923785)
- via manual download: [EZ-Template@3.2.0-beta.7+2c7763.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2264504008.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.7+2c7763.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2264504008.zip;
pros c fetch EZ-Template@3.2.0-beta.7+2c7763.zip;
pros c apply EZ-Template@3.2.0-beta.7+2c7763;
rm EZ-Template@3.2.0-beta.7+2c7763.zip;
```