### PR TITLE
Fix linter errors

### DIFF
--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -4,8 +4,8 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "main.h"
-#include "util.hpp"
+#include "EZ-Template/api.hpp"
+#include "api.h"
 
 using namespace ez;
 

--- a/src/EZ-Template/auton.cpp
+++ b/src/EZ-Template/auton.cpp
@@ -4,7 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "main.h"
+#include "EZ-Template/api.hpp"
 
 Auton::Auton() {
   Name = "";

--- a/src/EZ-Template/auton_selector.cpp
+++ b/src/EZ-Template/auton_selector.cpp
@@ -4,7 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "main.h"
+#include "EZ-Template/api.hpp"
 
 AutonSelector::AutonSelector() {
   auton_count = 0;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -8,7 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <list>
 
-#include "main.h"
+#include "EZ-Template/sdcard.hpp"
 #include "okapi/api/units/QAngle.hpp"
 #include "pros/llemu.hpp"
 #include "pros/screen.hpp"

--- a/src/EZ-Template/drive/pid_tuner.cpp
+++ b/src/EZ-Template/drive/pid_tuner.cpp
@@ -5,7 +5,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
 #include "EZ-Template/api.hpp"
-#include "EZ-Template/sdcard.hpp"
+#include "liblvgl/llemu.hpp"
 #include "pros/llemu.hpp"
 #include "pros/misc.h"
 

--- a/src/EZ-Template/drive/pto.cpp
+++ b/src/EZ-Template/drive/pto.cpp
@@ -8,7 +8,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <vector>
 
 #include "drive.hpp"
-#include "main.h"
 
 bool Drive::pto_check(pros::Motor check_if_pto) {
   auto does_exist = std::find(pto_active.begin(), pto_active.end(), check_if_pto.get_port());

--- a/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
@@ -4,8 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "EZ-Template/util.hpp"
-#include "main.h"
+#include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
 /////
@@ -139,7 +138,7 @@ void Drive::pid_drive_set(double target, int speed, bool slew_on, bool toggle_he
   // Prioritize custom fwd/rev constants.  Otherwise, use the same for fwd and rev
   if (fwd_rev_drivePID.constants_set_check() && !new_drive_pid->constants_set_check())
     new_drive_pid = &fwd_rev_drivePID;
-    
+
   PID::Constants pid_drive_consts = new_drive_pid->constants_get();
   leftPID.constants_set(pid_drive_consts.kp, pid_drive_consts.ki, pid_drive_consts.kd, pid_drive_consts.start_i);
   rightPID.constants_set(pid_drive_consts.kp, pid_drive_consts.ki, pid_drive_consts.kd, pid_drive_consts.start_i);

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -4,8 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "EZ-Template/util.hpp"
-#include "main.h"
+#include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
 /////

--- a/src/EZ-Template/drive/set_pid/set_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_pid.cpp
@@ -4,8 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "EZ-Template/util.hpp"
-#include "main.h"
+#include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
 // Updates max speed

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -4,8 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "EZ-Template/util.hpp"
-#include "main.h"
+#include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
 /////

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -4,8 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "EZ-Template/util.hpp"
-#include "main.h"
+#include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
 /////

--- a/src/EZ-Template/drive/user_input.cpp
+++ b/src/EZ-Template/drive/user_input.cpp
@@ -4,7 +4,8 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "main.h"
+#include "drive.hpp"
+#include "pros/misc.h"
 
 void Drive::opcontrol_arcade_scaling(bool enable) { arcade_vector_scaling = enable; }
 bool Drive::opcontrol_arcade_scaling_enabled() { return arcade_vector_scaling; }
@@ -292,12 +293,12 @@ void Drive::opcontrol_tank() {
   // Toggle for controller curve
   opcontrol_curve_buttons_iterate();
 
-  auto analog_left_value = master.get_analog(ANALOG_LEFT_Y);
-  auto analog_right_value = master.get_analog(ANALOG_RIGHT_Y);
+  auto analog_left_value = master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y);
+  auto analog_right_value = master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_Y);
 
   // Put the joysticks through the curve function
-  int l_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(ANALOG_LEFT_Y)));
-  int r_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(ANALOG_RIGHT_Y)));
+  int l_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y)));
+  int r_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_Y)));
 
   // Set robot to l_stick and r_stick, check joystick threshold, set active brake
   opcontrol_joystick_threshold_iterate(l_stick, r_stick);
@@ -315,12 +316,12 @@ void Drive::opcontrol_arcade_standard(e_type stick_type) {
   // Check arcade type (split vs single, normal vs flipped)
   if (stick_type == SPLIT) {
     // Put the joysticks through the curve function
-    fwd_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(ANALOG_LEFT_Y)));
-    turn_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(ANALOG_RIGHT_X)));
+    fwd_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y)));
+    turn_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_X)));
   } else if (stick_type == SINGLE) {
     // Put the joysticks through the curve function
-    fwd_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(ANALOG_LEFT_Y)));
-    turn_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(ANALOG_LEFT_X)));
+    fwd_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y)));
+    turn_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_X)));
   }
 
   // Set robot to l_stick and r_stick, check joystick threshold, set active brake
@@ -339,12 +340,12 @@ void Drive::opcontrol_arcade_flipped(e_type stick_type) {
   // Check arcade type (split vs single, normal vs flipped)
   if (stick_type == SPLIT) {
     // Put the joysticks through the curve function
-    fwd_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(ANALOG_RIGHT_Y)));
-    turn_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(ANALOG_LEFT_X)));
+    fwd_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_Y)));
+    turn_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_X)));
   } else if (stick_type == SINGLE) {
     // Put the joysticks through the curve function
-    fwd_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(ANALOG_RIGHT_Y)));
-    turn_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(ANALOG_RIGHT_X)));
+    fwd_stick = opcontrol_curve_right(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_Y)));
+    turn_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_X)));
   }
 
   // Set robot to l_stick and r_stick, check joystick threshold, set active brake

--- a/src/EZ-Template/sdcard.cpp
+++ b/src/EZ-Template/sdcard.cpp
@@ -9,6 +9,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <filesystem>
 
 #include "auton_selector.hpp"
+#include "liblvgl/llemu.hpp"
 #include "pros/llemu.hpp"
 #include "util.hpp"
 

--- a/src/EZ-Template/util.cpp
+++ b/src/EZ-Template/util.cpp
@@ -4,9 +4,10 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "util.hpp"
-
-#include "main.h"
+#include "EZ-Template/api.hpp"
+#include "liblvgl/llemu.hpp"
+#include "pros/llemu.hpp"
+#include "pros/misc.h"
 
 pros::Controller master(pros::E_CONTROLLER_MASTER);
 


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
No more linter errors in source code.  `main.h` includes were deleted everywhere too, and more specific includes were used instead

## Motivation:
<!-- Small explanation of why these changes need to be made -->
It was really annoying to work on before.  

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: fc8bebd55f7d52ae84c60bcc8b2b6fc490045e99 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12151937163)
- via manual download: [EZ-Template@3.2.0-beta.8+466516.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2271051397.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+466516.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2271051397.zip;
pros c fetch EZ-Template@3.2.0-beta.8+466516.zip;
pros c apply EZ-Template@3.2.0-beta.8+466516;
rm EZ-Template@3.2.0-beta.8+466516.zip;
```