### PR TITLE
Limited decimal points

### DIFF
--- a/include/EZ-Template/util.hpp
+++ b/include/EZ-Template/util.hpp
@@ -156,6 +156,9 @@ std::string exit_to_string(exit_output input);
 namespace util {
 extern bool AUTON_RAN;
 
+int places_after_decimal(double input, int min = 0);
+std::string to_string_with_precision(double input, int n = 2);
+
 /**
  * Returns 1 if input is positive and -1 if input is negative
  */

--- a/src/EZ-Template/drive/pid_tuner.cpp
+++ b/src/EZ-Template/drive/pid_tuner.cpp
@@ -5,6 +5,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
 #include "EZ-Template/api.hpp"
+#include "EZ-Template/util.hpp"
 #include "liblvgl/llemu.hpp"
 #include "pros/llemu.hpp"
 #include "pros/misc.h"
@@ -88,18 +89,23 @@ void Drive::pid_tuner_toggle() {
 void Drive::pid_tuner_print() {
   if (!pid_tuner_on) return;
 
-  std::string name = used_pid_tuner_pids->at(column).name + "\n";
-  std::string kp = "kp: " + std::to_string(used_pid_tuner_pids->at(column).consts->kp);
-  std::string ki = "ki: " + std::to_string(used_pid_tuner_pids->at(column).consts->ki);
-  std::string kd = "kd: " + std::to_string(used_pid_tuner_pids->at(column).consts->kd);
-  std::string starti = "start i: " + std::to_string(used_pid_tuner_pids->at(column).consts->start_i);
+  double kp = used_pid_tuner_pids->at(column).consts->kp;
+  double ki = used_pid_tuner_pids->at(column).consts->ki;
+  double kd = used_pid_tuner_pids->at(column).consts->kd;
+  double starti = used_pid_tuner_pids->at(column).consts->start_i;
 
-  kp = row == 0 ? kp + arrow : kp + "\n";
-  ki = row == 1 ? ki + arrow : ki + "\n";
-  kd = row == 2 ? kd + arrow : kd + "\n";
-  starti = row == 3 ? starti + arrow : starti + "\n";
+  std::string sname = used_pid_tuner_pids->at(column).name + "\n";
+  std::string skp = "kp: " + util::to_string_with_precision(kp, util::places_after_decimal(kp, 2));
+  std::string ski = "ki: " + util::to_string_with_precision(ki, util::places_after_decimal(ki, 2));
+  std::string skd = "kd: " + util::to_string_with_precision(kd, util::places_after_decimal(kd, 2));
+  std::string sstarti = "start i: " + util::to_string_with_precision(starti, util::places_after_decimal(starti, 2));
 
-  complete_pid_tuner_output = name + "\n" + kp + ki + kd + starti + "\n";
+  skp = row == 0 ? skp + arrow : skp + "\n";
+  ski = row == 1 ? ski + arrow : ski + "\n";
+  skd = row == 2 ? skd + arrow : skd + "\n";
+  sstarti = row == 3 ? sstarti + arrow : sstarti + "\n";
+
+  complete_pid_tuner_output = sname + "\n" + skp + ski + skd + sstarti + "\n";
 
   pid_tuner_print_brain();
   pid_tuner_print_terminal();

--- a/src/EZ-Template/drive/user_input.cpp
+++ b/src/EZ-Template/drive/user_input.cpp
@@ -171,12 +171,8 @@ void Drive::opcontrol_curve_buttons_iterate() {
     button_press(&r_decrease_, master.get_digital(r_decrease_.button), ([this] { this->r_decrease(); }), ([this] { this->save_r_curve_sd(); }));
   }
 
-  std::ostringstream short_sl, short_sr;
-  short_sl << std::fixed << std::setprecision(1) << left_curve_scale;
-  short_sr << std::fixed << std::setprecision(1) << right_curve_scale;
-
-  auto sr = short_sr.str();
-  auto sl = short_sl.str();
+  auto sl = util::to_string_with_precision(left_curve_scale, 1);
+  auto sr = util::to_string_with_precision(right_curve_scale, 1);
   if (!is_tank)
     master.set_text(2, 0, sl + "         " + sr);
   else

--- a/src/EZ-Template/util.cpp
+++ b/src/EZ-Template/util.cpp
@@ -126,6 +126,27 @@ std::string exit_to_string(exit_output input) {
 namespace util {
 bool AUTON_RAN = true;
 
+int places_after_decimal(double input, int min) {
+  std::string in = std::to_string(input);
+  int places_after_decimal = 6;
+  for (int i = in.length() - 1; i > 0; i--) {
+    if (in[i] == '.')
+      break;
+
+    if (in[i] == '0')
+      places_after_decimal--;
+    else
+      break;
+  }
+  return places_after_decimal < min ? min : places_after_decimal;
+}
+
+std::string to_string_with_precision(double input, int n) {
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(n) << input;
+  return out.str();
+}
+
 bool reversed_active(double input) {
   if (input < 0) return true;
   return false;


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Limited the amount of decimals that can be printed to the brain screen.  Some new functions were added to handle this and they are now being used in other places in EZ-Template.

Tracker screen and xya screen are now combined.  Users can see track width on the brain screen now, and will only see active trackers.

## Motivation:
<!-- Small explanation of why these changes need to be made -->
It looks wayyy nicer and is a setup for empirically getting track width

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: ab7a4e8bb1a76b02fcdb7b0553edaa6918397094 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12155205719)
- via manual download: [EZ-Template@3.2.0-beta.8+ab7a4e.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2271873102.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+ab7a4e.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2271873102.zip;
pros c fetch EZ-Template@3.2.0-beta.8+ab7a4e.zip;
pros c apply EZ-Template@3.2.0-beta.8+ab7a4e;
rm EZ-Template@3.2.0-beta.8+ab7a4e.zip;
```