### PR TITLE
Added unique vibration when imu fails

### DIFF
--- a/EZ-Template-Example-Project/src/main.cpp
+++ b/EZ-Template-Example-Project/src/main.cpp
@@ -66,7 +66,7 @@ void initialize() {
   // Initialize chassis and auton selector
   chassis.initialize();
   ez::as::initialize();
-  master.rumble(".");
+  master.rumble(chassis.drive_imu_calibrated() ? "." : "---");
 }
 
 /**

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -1180,6 +1180,13 @@ class Drive {
   bool drive_imu_calibrate(bool run_loading_animation = true);
 
   /**
+   * Checks if the imu calibrated successfully or if it took longer than expected.
+   *
+   * Returns true if calibrated successfully, and false if unsuccessful.
+   */
+  bool drive_imu_calibrated();
+
+  /**
    * Loading display while the IMU calibrates.
    */
   void drive_imu_display_loading(int iter);
@@ -3147,6 +3154,7 @@ class Drive {
   double odom_ime_track_width_right = 0.0;
 
  private:
+  bool imu_calibrate_weird = false;
   bool is_full_pid_tuner_enabled = false;
   std::vector<const_and_name>* used_pid_tuner_pids;
   double opcontrol_speed_max = 127.0;

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3154,7 +3154,7 @@ class Drive {
   double odom_ime_track_width_right = 0.0;
 
  private:
-  bool imu_calibrate_weird = false;
+  bool imu_calibrate_took_too_long = false;
   bool is_full_pid_tuner_enabled = false;
   std::vector<const_and_name>* used_pid_tuner_pids;
   double opcontrol_speed_max = 127.0;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -377,7 +377,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
       }
       if (iter >= 3000) {
         printf("No IMU plugged in, (took %d ms to realize that)\n", iter);
-        imu_calibrate_weird = true;
+        imu_calibrate_took_too_long = true;
         return false;
       }
     }
@@ -385,12 +385,12 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
   }
   printf("IMU is done calibrating (took %d ms)\n", iter);
   imu_calibration_complete = true;
-  imu_calibrate_weird = iter > 2000 ? true : false;
+  imu_calibrate_took_too_long = iter > 2000 ? true : false;
   return true;
 }
 
 bool Drive::drive_imu_calibrated() {
-  if (imu_calibration_complete && !imu_calibrate_weird)
+  if (imu_calibration_complete && !imu_calibrate_took_too_long)
     return true;
   return false;
 }

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -4,11 +4,9 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-#include "drive.hpp"
-
 #include <list>
 
-#include "EZ-Template/sdcard.hpp"
+#include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 #include "pros/llemu.hpp"
 #include "pros/screen.hpp"
@@ -379,6 +377,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
       }
       if (iter >= 3000) {
         printf("No IMU plugged in, (took %d ms to realize that)\n", iter);
+        imu_calibrate_weird = true;
         return false;
       }
     }
@@ -386,7 +385,14 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
   }
   printf("IMU is done calibrating (took %d ms)\n", iter);
   imu_calibration_complete = true;
+  imu_calibrate_weird = iter > 2000 ? true : false;
   return true;
+}
+
+bool Drive::drive_imu_calibrated() {
+  if (imu_calibration_complete && !imu_calibrate_weird)
+    return true;
+  return false;
 }
 
 // Brake modes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,7 @@ void initialize() {
   // Initialize chassis and auton selector
   chassis.initialize();
   ez::as::initialize();
-  master.rumble(".");
+  master.rumble(chassis.drive_imu_calibrated() ? "." : "---");
 }
 
 /**


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Added a new function that returns if the imu calibrated successfully or not, or if it took longer than expected.  

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Warn teams if their IMU doesn't calibrate properly.  

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] run the code with an imu plugged in and ensure there is one short vibration
- [ ] run the code with an imu unplugged and ensure there are three long vibrations
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: e78a695fb1d25f3f20ea9b0bc12a9ced6cb5e120 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12156511916)
- via manual download: [EZ-Template@3.2.0-beta.8+e78a69.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2272219752.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+e78a69.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2272219752.zip;
pros c fetch EZ-Template@3.2.0-beta.8+e78a69.zip;
pros c apply EZ-Template@3.2.0-beta.8+e78a69;
rm EZ-Template@3.2.0-beta.8+e78a69.zip;
```