### PR TITLE
Set xy without requiring angle

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -557,7 +557,7 @@ class Drive {
   /**
    * Sets a new pose for the robot
    *
-   * \param x
+   * \param pose
    *        {x, y, t} units in inches and degrees
    */
   void odom_pose_set(pose itarget);
@@ -565,10 +565,30 @@ class Drive {
   /**
    * Sets a new pose for the robot
    *
-   * \param x
+   * \param uited pose
    *        {x, y, t} as an okapi unit
    */
   void odom_pose_set(united_pose itarget);
+
+  /**
+   *Sets a new X and Y value for the robot
+   *
+   * \param x
+   *        new x value, in inches
+   * \param x
+   *        new y value, in inches
+   */
+  void odom_xy_set(double x, double y);
+
+  /**
+   * Sets a new X and Y value for the robot
+   *
+   * \param x
+   *        new x value, okapi unit
+   * \param x
+   *        new y value, okapi unit
+   */
+  void odom_xy_set(okapi::QLength p_x, okapi::QLength p_y);
 
   /**
    * Returns the current pose of the robot

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -565,13 +565,13 @@ class Drive {
   /**
    * Sets a new pose for the robot
    *
-   * \param uited pose
+   * \param united pose
    *        {x, y, t} as an okapi unit
    */
   void odom_pose_set(united_pose itarget);
 
   /**
-   *Sets a new X and Y value for the robot
+   * Sets a new X and Y value for the robot
    *
    * \param x
    *        new x value, in inches

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -17,6 +17,7 @@ void Drive::odom_x_set(double x) {
   central_pose.x = x;
   was_odom_just_set = true;
 }
+void Drive::odom_x_set(okapi::QLength p_x) { odom_x_set(p_x.convert(okapi::inch)); }
 void Drive::odom_y_set(double y) {
   odom_current.y = y;
   l_pose.y = y;
@@ -24,11 +25,9 @@ void Drive::odom_y_set(double y) {
   central_pose.y = y;
   was_odom_just_set = true;
 }
-void Drive::odom_theta_set(double a) { drive_angle_set(a); }
-void Drive::odom_x_set(okapi::QLength p_x) { odom_x_set(p_x.convert(okapi::inch)); }
 void Drive::odom_y_set(okapi::QLength p_y) { odom_y_set(p_y.convert(okapi::inch)); }
+void Drive::odom_theta_set(double a) { drive_angle_set(a); }
 void Drive::odom_theta_set(okapi::QAngle p_a) { odom_theta_set(p_a.convert(okapi::degree)); }
-void Drive::odom_reset() { odom_pose_set({0.0, 0.0, 0.0}); }
 void Drive::drive_width_set(double input) {
   global_track_width = fabs(input);
   if (input != 0.0) {
@@ -40,28 +39,26 @@ void Drive::drive_width_set(double input) {
   odom_ime_track_width_right = 0.0;
 }
 void Drive::drive_width_set(okapi::QLength p_input) { drive_width_set(p_input.convert(okapi::inch)); }
-double Drive::drive_width_get() { return global_track_width; }
-void Drive::odom_enable(bool input) { odometry_enabled = input; }
-bool Drive::odom_enabled() { return odometry_enabled; }
 void Drive::odom_xy_set(double x, double y) {
   odom_x_set(x);
   odom_y_set(y);
 }
-void Drive::odom_xy_set(okapi::QLength p_x, okapi::QLength p_y) {
-  odom_x_set(p_x.convert(okapi::inch));
-  odom_y_set(p_y.convert(okapi::inch));
-}
-void Drive::odom_pose_set(united_pose itarget) { odom_pose_set(util::united_pose_to_pose(itarget)); }
+void Drive::odom_xy_set(okapi::QLength p_x, okapi::QLength p_y) { odom_xy_set(p_x.convert(okapi::inch), p_y.convert(okapi::inch)); }
 void Drive::odom_pose_set(pose itarget) {
   odom_theta_set(itarget.theta);
   odom_x_set(itarget.x);
   odom_y_set(itarget.y);
 }
+void Drive::odom_pose_set(united_pose itarget) { odom_pose_set(util::united_pose_to_pose(itarget)); }
+void Drive::odom_reset() { odom_pose_set({0.0, 0.0, 0.0}); }
+void Drive::odom_enable(bool input) { odometry_enabled = input; }
+bool Drive::odom_enabled() { return odometry_enabled; }
 
 double Drive::odom_x_get() { return odom_current.x; }
 double Drive::odom_y_get() { return odom_current.y; }
 double Drive::odom_theta_get() { return odom_current.theta; }
 pose Drive::odom_pose_get() { return odom_current; }
+double Drive::drive_width_get() { return global_track_width; }
 
 std::pair<float, float> Drive::decide_vert_sensor(ez::tracking_wheel *tracker, bool is_tracker_enabled, float ime, float ime_track) {
   float current = ime;

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -43,6 +43,14 @@ void Drive::drive_width_set(okapi::QLength p_input) { drive_width_set(p_input.co
 double Drive::drive_width_get() { return global_track_width; }
 void Drive::odom_enable(bool input) { odometry_enabled = input; }
 bool Drive::odom_enabled() { return odometry_enabled; }
+void Drive::odom_xy_set(double x, double y) {
+  odom_x_set(x);
+  odom_y_set(y);
+}
+void Drive::odom_xy_set(okapi::QLength p_x, okapi::QLength p_y) {
+  odom_x_set(p_x.convert(okapi::inch));
+  odom_y_set(p_y.convert(okapi::inch));
+}
 void Drive::odom_pose_set(united_pose itarget) { odom_pose_set(util::united_pose_to_pose(itarget)); }
 void Drive::odom_pose_set(pose itarget) {
   odom_theta_set(itarget.theta);


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Can now set x 

## Motivation:
<!-- Small explanation of why these changes need to be made -->
You couldn't set xy without a :D

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 2ff559b9f9b2b48feda48f1a9aec65233fe3f2a7 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12156423849)
- via manual download: [EZ-Template@3.2.0-beta.8+2ff559.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2272193368.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+2ff559.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2272193368.zip;
pros c fetch EZ-Template@3.2.0-beta.8+2ff559.zip;
pros c apply EZ-Template@3.2.0-beta.8+2ff559;
rm EZ-Template@3.2.0-beta.8+2ff559.zip;
```