### PR TITLE
Added xyt set

### DIFF
--- a/EZ-Template-Example-Project/src/main.cpp
+++ b/EZ-Template-Example-Project/src/main.cpp
@@ -103,11 +103,11 @@ void competition_initialize() {
  * from where it left off.
  */
 void autonomous() {
-  chassis.pid_targets_reset();                 // Resets PID targets to 0
-  chassis.drive_imu_reset();                   // Reset gyro position to 0
-  chassis.drive_sensor_reset();                // Reset drive sensors to 0
-  chassis.odom_pose_set({0_in, 0_in, 0_deg});  // Set the current position, you can start at a specific position with this
-  chassis.drive_brake_set(MOTOR_BRAKE_HOLD);   // Set motors to hold.  This helps autonomous consistency
+  chassis.pid_targets_reset();                // Resets PID targets to 0
+  chassis.drive_imu_reset();                  // Reset gyro position to 0
+  chassis.drive_sensor_reset();               // Reset drive sensors to 0
+  chassis.odom_xyt_set(0_in, 0_in, 0_deg);    // Set the current position, you can start at a specific position with this
+  chassis.drive_brake_set(MOTOR_BRAKE_HOLD);  // Set motors to hold.  This helps autonomous consistency
 
   /*
   Odometry and Pure Pursuit are not magic

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -575,7 +575,7 @@ class Drive {
    *
    * \param x
    *        new x value, in inches
-   * \param x
+   * \param y
    *        new y value, in inches
    */
   void odom_xy_set(double x, double y);
@@ -583,12 +583,36 @@ class Drive {
   /**
    * Sets a new X and Y value for the robot
    *
-   * \param x
+   * \param p_x
    *        new x value, okapi unit
-   * \param x
+   * \param p_y
    *        new y value, okapi unit
    */
   void odom_xy_set(okapi::QLength p_x, okapi::QLength p_y);
+
+  /**
+   * Sets a new X, Y, and Theta value for the robot
+   *
+   * \param x
+   *        new x value, in inches
+   * \param y
+   *        new y value, in inches
+   * \param t
+   *        new theta value, in degrees
+   */
+  void odom_xyt_set(double x, double y, double t);
+
+  /**
+   * Sets a new X, Y, and Theta value for the robot
+   *
+   * \param p_x
+   *        new x value, okapi unit
+   * \param p_y
+   *        new y value, okapi unit
+   * \param p_t
+   *        new theta value, okapi unit
+   */
+  void odom_xyt_set(okapi::QLength p_x, okapi::QLength p_y, okapi::QAngle p_t);
 
   /**
    * Returns the current pose of the robot

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -44,10 +44,16 @@ void Drive::odom_xy_set(double x, double y) {
   odom_y_set(y);
 }
 void Drive::odom_xy_set(okapi::QLength p_x, okapi::QLength p_y) { odom_xy_set(p_x.convert(okapi::inch), p_y.convert(okapi::inch)); }
+void Drive::odom_xyt_set(double x, double y, double t) {
+  odom_x_set(x);
+  odom_y_set(y);
+  odom_theta_set(t);
+}
+void Drive::odom_xyt_set(okapi::QLength p_x, okapi::QLength p_y, okapi::QAngle p_t) { odom_xyt_set(p_x.convert(okapi::inch), p_y.convert(okapi::inch), p_t.convert(okapi::degree)); }
 void Drive::odom_pose_set(pose itarget) {
-  odom_theta_set(itarget.theta);
   odom_x_set(itarget.x);
   odom_y_set(itarget.y);
+  odom_theta_set(itarget.theta);
 }
 void Drive::odom_pose_set(united_pose itarget) { odom_pose_set(util::united_pose_to_pose(itarget)); }
 void Drive::odom_reset() { odom_pose_set({0.0, 0.0, 0.0}); }
@@ -60,7 +66,7 @@ double Drive::odom_theta_get() { return odom_current.theta; }
 pose Drive::odom_pose_get() { return odom_current; }
 double Drive::drive_width_get() { return global_track_width; }
 
-std::pair<float, float> Drive::decide_vert_sensor(ez::tracking_wheel *tracker, bool is_tracker_enabled, float ime, float ime_track) {
+std::pair<float, float> Drive::decide_vert_sensor(ez::tracking_wheel* tracker, bool is_tracker_enabled, float ime, float ime_track) {
   float current = ime;
   float track_width = ime_track;
   if (is_tracker_enabled) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,11 +103,11 @@ void competition_initialize() {
  * from where it left off.
  */
 void autonomous() {
-  chassis.pid_targets_reset();                 // Resets PID targets to 0
-  chassis.drive_imu_reset();                   // Reset gyro position to 0
-  chassis.drive_sensor_reset();                // Reset drive sensors to 0
-  chassis.odom_pose_set({0_in, 0_in, 0_deg});  // Set the current position, you can start at a specific position with this
-  chassis.drive_brake_set(MOTOR_BRAKE_HOLD);   // Set motors to hold.  This helps autonomous consistency
+  chassis.pid_targets_reset();                // Resets PID targets to 0
+  chassis.drive_imu_reset();                  // Reset gyro position to 0
+  chassis.drive_sensor_reset();               // Reset drive sensors to 0
+  chassis.odom_xyt_set(0_in, 0_in, 0_deg);    // Set the current position, you can start at a specific position with this
+  chassis.drive_brake_set(MOTOR_BRAKE_HOLD);  // Set motors to hold.  This helps autonomous consistency
 
   /*
   Odometry and Pure Pursuit are not magic


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Added `chassis.odom_xyt_set(x, y, t);`

## Motivation:
<!-- Small explanation of why these changes need to be made -->
If someone used `chassis.odom_pose_set({60, 60});`, their theta would reset to 0 silently.  I don't think this is obvious, and `xyt` set solves this problem.  Now users can do the following, with and without okapi units:
```cpp
chassis.odom_x_set(x);
chassis.odom_y_set(y);
chassis.odom_theta_set(t);
chassis.odom_xy_set(x, y);
chassis.odom_xyt_set(x, y, theta);

ez::pose new_pose = {x, y, theta};
chassis.odom_pose_set(new_pose);
```

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
An extension of #213 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 9c3f7df969d3659a70c20d22d66f4acd5ed66ac0 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12169000724)
- via manual download: [EZ-Template@3.2.0-beta.8+9c3f7d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2276128758.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+9c3f7d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2276128758.zip;
pros c fetch EZ-Template@3.2.0-beta.8+9c3f7d.zip;
pros c apply EZ-Template@3.2.0-beta.8+9c3f7d;
rm EZ-Template@3.2.0-beta.8+9c3f7d.zip;
```