### PR TITLE
Changed comments on pid_turn_set to more accurately reflect absolute turns

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -743,7 +743,7 @@ class Drive {
   void pid_drive_set(double target, int speed, bool slew_on = false, bool toggle_heading = true);
 
   /**
-   * Sets the robot to turn using PID.
+   * Sets the robot to turn relative to initial heading using PID.
    *
    * \param target
    *        target value as a double, unit is degrees
@@ -755,10 +755,10 @@ class Drive {
   void pid_turn_set(double target, int speed, bool slew_on = false);
 
   /**
-   * Sets the robot to turn using PID with okapi units.
+   * Sets the robot to turn relative to initial heading using PID with okapi units.
    *
    * \param p_target
-   *        target value in degrees
+   *        target value in okapi angle units
    * \param speed
    *        0 to 127, max speed during motion
    * \param slew_on


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Just made better documentation by changing comments on pid_turn_set to explain absolute turns in the same way that relative does

## Motivation:
<!-- Small explanation of why these changes need to be made -->
This makes documentation in-code better, allows people who don't check docs to understand the difference

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
No tests should be required, since it's just comments and documentation. Might be nice to check with newer people, just in case.

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a69db2b1211cc23a6e7013f4e7e1c9425fa04e6d -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12180311795)
- via manual download: [EZ-Template@3.1.0+c3d7aa.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2279190390.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.1.0+c3d7aa.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2279190390.zip;
pros c fetch EZ-Template@3.1.0+c3d7aa.zip;
pros c apply EZ-Template@3.1.0+c3d7aa;
rm EZ-Template@3.1.0+c3d7aa.zip;
```