### PR TITLE
Active brake uses PID class and doesn't reset drive sensors

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -127,6 +127,8 @@ class Drive {
   PID odom_angularPID;
   PID internal_leftPID;
   PID internal_rightPID;
+  PID left_activebrakePID;
+  PID right_activebrakePID;
 
   /**
    * Slew objects.
@@ -968,17 +970,28 @@ class Drive {
   std::vector<double> opcontrol_curve_default_get();
 
   /**
-   * Runs a P loop on the drive when the joysticks are released.
+   * Runs a PID loop on the drive when the joysticks are released.
    *
-   * \param kp
-   *        constant for the p loop
+   * \param p
+   *        kP
+   * \param i
+   *        kI, defaulted to 0
+   * \param d
+   *        kD, defaulted to 0
+   * \param p_start_i
+   *        start_I, defaulted to 0
    */
-  void opcontrol_drive_activebrake_set(double kp);
+  void opcontrol_drive_activebrake_set(double kp, double ki = 0.0, double kd = 0.0, double start_i = 0.0);
 
   /**
    * Returns kP for active brake.
    */
   double opcontrol_drive_activebrake_get();
+
+  /**
+   * Returns all PID constants for active brake.
+   */
+  PID::Constants opcontrol_drive_activebrake_constants_get();
 
   /**
    * Enables/disables modifying the joystick input curves with the controller.
@@ -3375,6 +3388,7 @@ class Drive {
   bool opcontrol_arcade_scaling_enabled();
 
  private:
+  void opcontrol_drive_activebrake_targets_set();
   bool odom_use_left = true;
   double odom_ime_track_width_left = 0.0;
   double odom_ime_track_width_right = 0.0;
@@ -3527,11 +3541,6 @@ class Drive {
    * Heading bool.
    */
   bool heading_on = true;
-
-  /**
-   * Active brake kp constant.
-   */
-  double active_brake_kp = 0;
 
   /**
    * Tick per inch calculation.

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -254,10 +254,17 @@ int Drive::drive_current_limit_get() {
 
 // Motor telemetry
 void Drive::drive_sensor_reset() {
+  // Update active brake constants
+  left_activebrakePID.target_set(0.0);
+  right_activebrakePID.target_set(0.0);
+
+  // Reset odom stuff
   h_last = 0.0;
   l_last = 0.0;
   r_last = 0.0;
   t_last = 0.0;
+
+  // Reset sensors
   left_motors.front().tare_position();
   right_motors.front().tare_position();
   if (odom_tracker_left_enabled) odom_tracker_left->reset();


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Active brake now uses pid class and doesn't reset drive sensors.

## Motivation:
<!-- Small explanation of why these changes need to be made -->
This will help debugging in opcontrol because drive sensors won't get reset constantly

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] ensure active brake works like normal
- [ ] ensure active brake works when enabling and disabling active brake
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 869d66805d5656dcfb94bddad92e6654f5594f4f -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12289077724)
- via manual download: [EZ-Template@3.2.0-beta.8+869d66.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2309515890.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+869d66.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2309515890.zip;
pros c fetch EZ-Template@3.2.0-beta.8+869d66.zip;
pros c apply EZ-Template@3.2.0-beta.8+869d66;
rm EZ-Template@3.2.0-beta.8+869d66.zip;
```