### PR TITLE
Added constants for path smoothing

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -775,6 +775,35 @@ class Drive {
   double odom_path_spacing_get();
 
   /**
+   * Sets the constants for smoothing out a path.
+   *
+   * Path smoothing based on https://medium.com/@jaems33/understanding-robot-motion-path-smoothing-5970c8363bc4
+   *
+   * \param weight_smooth
+   *        how much weight to update the data
+   * \param weight_data
+   *        how much weight to smooth the coordinates
+   * \param tolerance
+   *        how much change per iteration is necessary to keep iterating
+   */
+  void odom_path_smooth_constants_set(double weight_smooth, double weight_data, double tolerance);
+
+  /**
+   * Returns the constants for smoothing out a path.
+   *
+   * In order of:
+   *  - weight_smooth
+   *  - weight_data
+   *  - tolerance
+   */
+  std::vector<double> odom_path_smooth_constants_get();
+
+  /**
+   * Prints the current path the robot is following.
+   */
+  void odom_path_print();
+
+  /**
    * How far away the robot looks in the path during pure pursuits.
    *
    * \param distance
@@ -3375,6 +3404,9 @@ class Drive {
   bool opcontrol_arcade_scaling_enabled();
 
  private:
+  double odom_smooth_weight_smooth = 0.0;
+  double odom_smooth_weight_data = 0.0;
+  double odom_smooth_tolerance = 0.0;
   bool odom_use_left = true;
   double odom_ime_track_width_left = 0.0;
   double odom_ime_track_width_right = 0.0;
@@ -3387,7 +3419,7 @@ class Drive {
   std::vector<odom> pp_movements;
   std::vector<int> injected_pp_index;
   int pp_index = 0;
-  std::vector<odom> smooth_path(std::vector<odom> ipath, double weight_smooth = 0.75, double weight_data = 0.03, double tolerance = 0.0001);
+  std::vector<odom> smooth_path(std::vector<odom> ipath, double weight_smooth, double weight_data, double tolerance);
   double is_past_target(pose target, pose current);
   void raw_pid_odom_pp_set(std::vector<odom> imovements, bool slew_on);
   bool ptf1_running = false;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -162,6 +162,14 @@ void Drive::drive_defaults_set() {
   pid_turn_min_set(30);
   pid_swing_min_set(30);
 
+  // Path Constants
+  odom_path_smooth_constants_set(0.75, 0.03, 0.0001);
+  odom_path_spacing_set(0.5_in);
+  odom_turn_bias_set(0.9);
+  odom_look_ahead_set(7_in);
+  odom_boomerang_distance_set(16_in);
+  odom_boomerang_dlead_set(0.625);
+
   // Slew constants
   slew_turn_constants_set(3_deg, 70);
   slew_drive_constants_set(3_in, 70);
@@ -174,6 +182,9 @@ void Drive::drive_defaults_set() {
   pid_odom_turn_exit_condition_set(90_ms, 3_deg, 250_ms, 7_deg, 500_ms, 750_ms);
   pid_odom_drive_exit_condition_set(90_ms, 1_in, 250_ms, 3_in, 500_ms, 750_ms);
 
+  pid_odom_behavior_set(ez::shortest);  // Default odom turning to shortest
+
+  // Motion chaining
   pid_turn_chain_constant_set(3_deg);
   pid_swing_chain_constant_set(5_deg);
   pid_drive_chain_constant_set(3_in);


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Added constants for path smoothing and a function to print the path to terminal

## Motivation:
<!-- Small explanation of why these changes need to be made -->
If path spacing changes, smoothing constants will need to change too.  Now teams can edit smoothing constants and look at the current path in terminal.  

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] modify constants and ensure the path actually changes
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 864408ad7bb944c754ee3e3a6f53211603b6dc42 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12288574606)
- via manual download: [EZ-Template@3.2.0-beta.8+e3e48b.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2309382670.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+e3e48b.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2309382670.zip;
pros c fetch EZ-Template@3.2.0-beta.8+e3e48b.zip;
pros c apply EZ-Template@3.2.0-beta.8+e3e48b;
rm EZ-Template@3.2.0-beta.8+e3e48b.zip;
```