### PR TITLE
Default pid_odom_set is no longer forced to boomerang

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -105,7 +105,7 @@ void Drive::pid_odom_set(double target, int speed) {
 void Drive::pid_odom_set(double target, int speed, bool slew_on) {
   drive_directions fwd_or_rev = util::sgn(target) >= 0 ? fwd : rev;
   pose target_pose = util::vector_off_point(target, {odom_x_get(), odom_y_get(), headingPID.target_get()});
-  odom path = {target_pose, fwd_or_rev, speed};
+  odom path = {{target_pose.x, target_pose.y}, fwd_or_rev, speed};
 
   xyPID.timers_reset();
   current_a_odomPID.timers_reset();


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->

## Motivation:
<!-- Small explanation of why these changes need to be made -->

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 5b57d3223205ef37d0a8a475f6b06d15f1fe3623 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12290429381)
- via manual download: [EZ-Template@3.2.0-beta.8+5b57d3.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2309855809.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-beta.8+5b57d3.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2309855809.zip;
pros c fetch EZ-Template@3.2.0-beta.8+5b57d3.zip;
pros c apply EZ-Template@3.2.0-beta.8+5b57d3;
rm EZ-Template@3.2.0-beta.8+5b57d3.zip;
```