### PR TITLE
Relative odom works with axis flipped

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -111,7 +111,7 @@ void Drive::pid_odom_set(double target, int speed, bool slew_on) {
   current_a_odomPID.timers_reset();
 
   if (print_toggle) printf("Injected ");
-  std::vector<odom> input_path = inject_points(set_odoms_direction({path}));
+  std::vector<odom> input_path = inject_points({path});
   odom_turn_bias_enable(false);
   current_slew_on = slew_on;
   slew_min_when_it_enabled = 0;
@@ -410,7 +410,7 @@ void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on) {
     slew_will_enable_later = true;
   }
   target = new_turn_target_compute(target, odom_imu_start, current_angle_behavior);
-  headingPID.target_set(flip_angle_target(target));
+  headingPID.target_set(target);
 
   // Set targets
   odom_target.x = imovement.target.x;

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -410,7 +410,7 @@ void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on) {
     slew_will_enable_later = true;
   }
   target = new_turn_target_compute(target, odom_imu_start, current_angle_behavior);
-  headingPID.target_set(target);
+  headingPID.target_set(flip_angle_target(target));
 
   // Set targets
   odom_target.x = imovement.target.x;


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->

## Motivation:
<!-- Small explanation of why these changes need to be made -->

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 93602a18a4ca2f50d495baf8782971a61d441174 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12341915840)
- via manual download: [EZ-Template@3.2.0-rc.1+93602a.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2323333505.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.0-rc.1+93602a.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2323333505.zip;
pros c fetch EZ-Template@3.2.0-rc.1+93602a.zip;
pros c apply EZ-Template@3.2.0-rc.1+93602a;
rm EZ-Template@3.2.0-rc.1+93602a.zip;
```