### PR TITLE
✨Tracking is now an std::function

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3410,7 +3410,33 @@ class Drive {
    */
   bool opcontrol_arcade_scaling_enabled();
 
+  /**
+   * Current odom position.
+   */
+  pose odom_current = {0.0, 0.0, 0.0};
+
+  /**
+   * Tracking task that uses tracking wheels, this is used by default.
+   */
+  void tracking_wheels_tracking();
+
+  /**
+   * Sets a new task to use for tracking.
+   *
+   * In this function, you must:
+   *  - odom_current.x =
+   *  - odom_current.y =
+   *  - odom_current.theta =
+   *
+   * This function does not need to loop, that is done for you in EZ-Template.
+   *
+   * \param tracking_task
+   *        new function for tracking
+   */
+  void odom_tracking_set(std::function<void(void)> tracking_task);
+
  private:
+  std::function<void(void)> tracking;
   void opcontrol_drive_activebrake_targets_set();
   double odom_smooth_weight_smooth = 0.0;
   double odom_smooth_weight_data = 0.0;
@@ -3454,7 +3480,6 @@ class Drive {
   double global_track_width = 0.0;
   bool odometry_enabled = true;
   pose odom_target = {0.0, 0.0, 0.0};
-  pose odom_current = {0.0, 0.0, 0.0};
   pose odom_second_to_last = {0.0, 0.0, 0.0};
   pose odom_start = {0.0, 0.0, 0.0};
   pose odom_target_start = {0.0, 0.0, 0.0};

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -152,6 +152,9 @@ void Drive::drive_defaults_set() {
   std::cout << std::fixed;
   std::cout << std::setprecision(2);
 
+  // Set tracking task, user can override this if they want
+  odom_tracking_set(std::bind(&ez::Drive::tracking_wheels_tracking, this));
+
   // PID Constants
   pid_drive_constants_set(20.0, 0.0, 100.0);
   pid_heading_constants_set(11.0, 0.0, 20.0);


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Users can now make their own tracking functions.

## Motivation:
<!-- Small explanation of why these changes need to be made -->
With teams wanting to use MCL and VEXU teams using the sparkfun OTOS, EZ-Template needs a way to support custom tracking.

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#246 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
- [x] Run this code and ensure that XYT doesn't updating.
```cpp
void new_tracking() {
  printf("custom tracking task\n");
}

void initialize() {
  // Print our branding over your terminal :D
  ez::ez_template_print();

  pros::delay(500);  // Stop the user from doing anything while legacy ports configure

  chassis.odom_tracking_set(new_tracking);
  // . . .
```

- [x] Comment out the line of code below and ensure XYT does update.
```cpp
// chassis.odom_tracking_set(new_tracking);
```

- [x] Ensure that setting a custom XYT actually works
```cpp
void new_tracking() {
  chassis.odom_current.x = something;
  chassis.odom_current.y = something;
  chassis.odom_current.theta = chassis.drive_imu_get();
}

void initialize() {
  // Print our branding over your terminal :D
  ez::ez_template_print();

  pros::delay(500);  // Stop the user from doing anything while legacy ports configure

  chassis.odom_tracking_set(new_tracking);
  // . . .
```

## Download the template for this pull request:
Note

This is auto generated from [Add Template to Pull Request](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12408548307)

* via manual download: [EZ-Template@3.2.1+3e584a.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2341902030.zip)
* via PROS Integrated Terminal:
```
curl -o EZ-Template@3.2.1+3e584a.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2341902030.zip;
pros c fetch EZ-Template@3.2.1+3e584a.zip;
pros c apply EZ-Template@3.2.1+3e584a;
rm EZ-Template@3.2.1+3e584a.zip;
```