### PR TITLE
Added pros button support for piston::toggle

### DIFF
--- a/include/EZ-Template/piston.hpp
+++ b/include/EZ-Template/piston.hpp
@@ -7,6 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #pragma once
 
 #include "api.h"
+#include "pros/misc.h"
 
 namespace ez {
 class Piston {
@@ -60,6 +61,14 @@ class Piston {
    *        an input button
    */
   void button_toggle(int toggle);
+
+  /**
+   * One button toggle for the piston.
+   *
+   * \param toggle
+   *        an input button
+   */
+  void button_toggle(pros::controller_digital_e_t toggle);
 
   /**
    * Two buttons trigger the piston.  Active is enabled, deactive is disabled.

--- a/src/EZ-Template/piston.cpp
+++ b/src/EZ-Template/piston.cpp
@@ -5,6 +5,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
 #include "EZ-Template/piston.hpp"
+#include "pros/misc.h"
+#include "util.hpp"
 
 using namespace ez;
 
@@ -35,6 +37,15 @@ void Piston::button_toggle(int toggle) {
     set(!get());
   }
   last_press = toggle;
+}
+
+// Toggle for user control, takes in a pros button
+void Piston::button_toggle(pros::controller_digital_e_t toggle) {
+  int press = master.get_digital(toggle);
+  if (press && !last_press) {
+    set(!get());
+  }
+  last_press = press;
 }
 
 // Two button control for piston


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Added an overload for ez::Piston::button_toggle() for pros::controller_digital_e_t

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Allows users to input buttons instead of readings from the controller

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
Closes #254 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Ensure that ez::Piston::button_toggle(pros::E_CONTROLLER_DIGITAL_x) works the same as ez::Piston::button_toggle(master.get_digital(pros::E_CONTROLLER_DIGITAL_x).

- [ ] test item