### PR TITLE
🐛 Right swings now work without flipping rotation axis

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -291,9 +291,9 @@ void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_s
   used_motion_chain_scale = 0.0;
 
   // Flip the swing from left-right if rotation axis is flipped
-  if (odom_theta_direction_get()) 
-    current_swing = type == ez::LEFT_SWING ? ez::RIGHT_SWING : ez::LEFT_SWING;
-  
+  current_swing = type;
+  if (odom_theta_direction_get())
+    current_swing = current_swing == ez::LEFT_SWING ? ez::RIGHT_SWING : ez::LEFT_SWING;
 
   // Figure out if going forward or backward
   int side = type == ez::LEFT_SWING ? 1 : -1;


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Right swings now work.

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Without the rotation axis flipped, all swings were left swings.

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->

- [x] ensure the following code works as expected
```cpp
chassis.pid_swing_set(ez::LEFT_SWING, -45_deg, 110, 55);
chassis.pid_wait();

chassis.pid_swing_set(ez::LEFT_SWING, 0_deg, 110, 55);
chassis.pid_wait();

chassis.pid_swing_set(ez::RIGHT_SWING, -45_deg, 110, 55);
chassis.pid_wait();

chassis.pid_swing_set(ez::RIGHT_SWING, 0_deg, 110, 55);
chassis.pid_wait();
```
- [x] ensure the above code still works when this is added to the start
```cpp
chassis.odom_theta_flip();
```

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 5e7261a7dcdbe1d7a4a1b00417704bfcfa8ce8ff -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/12565542552)
- via manual download: [EZ-Template@3.2.1+5e7261.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2375403930.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.1+5e7261.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2375403930.zip;
pros c fetch EZ-Template@3.2.1+5e7261.zip;
pros c apply EZ-Template@3.2.1+5e7261;
rm EZ-Template@3.2.1+5e7261.zip;
```