### PR TITLE
✨Add an optional parameter for running the loading bar

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -379,7 +379,7 @@ class Drive {
   /**
    * Calibrates imu and initializes sd card to curve.
    */
-  void initialize();
+  void initialize(bool run_loading_animation = true);
 
   /**
    * Tasks for autonomous.

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -429,9 +429,9 @@ pros::motor_brake_mode_e_t Drive::drive_brake_get() {
   return CURRENT_BRAKE;
 }
 
-void Drive::initialize() {
+void Drive::initialize(bool run_loading_animation) {
   opcontrol_curve_sd_initialize();
-  drive_imu_calibrate();
+  drive_imu_calibrate(run_loading_animation);
   drive_sensor_reset();
 }
 


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Simply added an optional parameter to use the loading bar
## Motivation:
<!-- Small explanation of why these changes need to be made -->
Allows people to disable loading bar if they want while still using chassis.initialize()
### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
closes #272 
## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Check that initialize() works as intended still
- [ ] test item
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: ca9c06d6ea9d0ffd0d614bd42acdef1713145f5c -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/15233491467)
- via manual download: [EZ-Template@3.2.2+edbb0a.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/3191835740.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.2+edbb0a.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/3191835740.zip;
pros c fetch EZ-Template@3.2.2+edbb0a.zip;
pros c apply EZ-Template@3.2.2+edbb0a;
rm EZ-Template@3.2.2+edbb0a.zip;
```