### PR TITLE
Uses central pose for two vert trackers

### DIFF
--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -207,20 +207,10 @@ void Drive::ez_tracking_task() {
       odom_current.y = r_pose.y;
     }
   }
-  // If both sides have a sensor (2 vert trackers or 0 trackers), let the user pick what side
-  //  defaults to left tracker and central ime
+  // If both sides of a sensor, use central xy
   else {
-    // If using IMEs, use central pose
-    if (is_tracker == DRIVE_INTEGRATED) {
-      odom_current.x = central_pose.x;
-      odom_current.y = central_pose.y;
-    } else if (odom_use_left) {
-      odom_current.x = l_pose.x;
-      odom_current.y = l_pose.y;
-    } else {
-      odom_current.x = r_pose.x;
-      odom_current.y = r_pose.y;
-    }
+    odom_current.x = central_pose.x;
+    odom_current.y = central_pose.y;
   }
 
   odom_current.theta = drive_imu_get();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,9 @@ ez::Drive chassis(
 // ez::tracking_wheel horiz_tracker(8, 2.75, 4.0);  // This tracking wheel is perpendicular to the drive wheels
 // ez::tracking_wheel vert_tracker(9, 2.75, 4.0);   // This tracking wheel is parallel to the drive wheels
 
+ez::tracking_wheel left_tracker({'A', 'B'}, 2.75, 4.0);
+ez::tracking_wheel right_tracker({'C', 'D'}, 2.75, 4.0);
+
 /**
  * Runs initialization code. This occurs as soon as the program is started.
  *
@@ -43,6 +46,9 @@ void initialize() {
   //  - change `left` to `right` if the tracking wheel is to the right of the centerline
   //  - ignore this if you aren't using a vertical tracker
   // chassis.odom_tracker_left_set(&vert_tracker);
+
+  chassis.odom_tracker_left_set(&left_tracker);
+  chassis.odom_tracker_right_set(&right_tracker);
 
   // Configure your chassis controls
   chassis.opcontrol_curve_buttons_toggle(true);   // Enables modifying the controller curve with buttons on the joysticks


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
When using a left and a right vert tracker, EZ-Template will now use the average of both so no track width is needed, juts like with IMEs.

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Some teams having issues with two vertical tracking wheels and tracking

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: dfe01bbb820d9c7b5ba5f8ed9c4538395b719d52 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/13692618461)
- via manual download: [EZ-Template@3.2.2+970f4e.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2701556189.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.2+970f4e.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/2701556189.zip;
pros c fetch EZ-Template@3.2.2+970f4e.zip;
pros c apply EZ-Template@3.2.2+970f4e;
rm EZ-Template@3.2.2+970f4e.zip;
```