### PR TITLE
🐛 Bug/namespace

### DIFF
--- a/EZ-Template-Example-Project/include/EZ-Template/drive/drive.hpp
+++ b/EZ-Template-Example-Project/include/EZ-Template/drive/drive.hpp
@@ -20,8 +20,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "pros/motor_group.hpp"
 #include "pros/motors.h"
 
-//using namespace ez;
-
 namespace ez {
 class Drive {
  public:

--- a/EZ-Template-Example-Project/include/EZ-Template/drive/drive.hpp
+++ b/EZ-Template-Example-Project/include/EZ-Template/drive/drive.hpp
@@ -20,7 +20,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "pros/motor_group.hpp"
 #include "pros/motors.h"
 
-using namespace ez;
+//using namespace ez;
 
 namespace ez {
 class Drive {

--- a/EZ-Template-Example-Project/include/subsystems.hpp
+++ b/EZ-Template-Example-Project/include/subsystems.hpp
@@ -3,7 +3,7 @@
 #include "EZ-Template/api.hpp"
 #include "api.h"
 
-extern Drive chassis;
+extern ez::Drive chassis;
 
 // Your motors, sensors, etc. should go here.  Below are examples
 

--- a/EZ-Template-Example-Project/src/autons.cpp
+++ b/EZ-Template-Example-Project/src/autons.cpp
@@ -15,7 +15,7 @@ const int SWING_SPEED = 110;
 ///
 void default_constants() {
   // P, I, D, and Start I
-  chassis.pid_drive_constants_set(20.0, 0.0, 100.0);         // Fwd/rev constants, used for odom and non odom motions
+  chassis.pid_drive_constants_set(20.0, 0.0, 100.0);         // fwd/rev constants, used for odom and non odom motions
   chassis.pid_heading_constants_set(11.0, 0.0, 20.0);        // Holds the robot straight while going forward without odom
   chassis.pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);     // Turn in place constants
   chassis.pid_swing_constants_set(6.0, 0.0, 65.0);           // Swing constants
@@ -259,14 +259,14 @@ void odom_drive_example() {
 ///
 void odom_pure_pursuit_example() {
   // Drive to 0, 30 and pass through 6, 10 and 0, 20 on the way, with slew
-  chassis.pid_odom_set({{{6_in, 10_in}, fwd, DRIVE_SPEED},
-                        {{0_in, 20_in}, fwd, DRIVE_SPEED},
-                        {{0_in, 30_in}, fwd, DRIVE_SPEED}},
+  chassis.pid_odom_set({{{6_in, 10_in}, ez::fwd, DRIVE_SPEED},
+                        {{0_in, 20_in}, ez::fwd, DRIVE_SPEED},
+                        {{0_in, 30_in}, ez::fwd, DRIVE_SPEED}},
                        true);
   chassis.pid_wait();
 
   // Drive to 0, 0 backwards
-  chassis.pid_odom_set({{0_in, 0_in}, rev, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 0_in}, ez::rev, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 }
@@ -275,9 +275,9 @@ void odom_pure_pursuit_example() {
 // Odom Pure Pursuit Wait Until
 ///
 void odom_pure_pursuit_wait_until_example() {
-  chassis.pid_odom_set({{{0_in, 24_in}, fwd, DRIVE_SPEED},
-                        {{12_in, 24_in}, fwd, DRIVE_SPEED},
-                        {{24_in, 24_in}, fwd, DRIVE_SPEED}},
+  chassis.pid_odom_set({{{0_in, 24_in}, ez::fwd, DRIVE_SPEED},
+                        {{12_in, 24_in}, ez::fwd, DRIVE_SPEED},
+                        {{24_in, 24_in}, ez::fwd, DRIVE_SPEED}},
                        true);
   chassis.pid_wait_until_index(1);  // Waits until the robot passes 12, 24
   // Intake.move(127);  // Set your intake to start moving once it passes through the second point in the index
@@ -289,11 +289,11 @@ void odom_pure_pursuit_wait_until_example() {
 // Odom Boomerang
 ///
 void odom_boomerang_example() {
-  chassis.pid_odom_set({{0_in, 24_in, 45_deg}, fwd, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 24_in, 45_deg}, ez::fwd, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 
-  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, rev, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, ez::rev, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 }
@@ -302,13 +302,13 @@ void odom_boomerang_example() {
 // Odom Boomerang Injected Pure Pursuit
 ///
 void odom_boomerang_injected_pure_pursuit_example() {
-  chassis.pid_odom_set({{{0_in, 24_in, 45_deg}, fwd, DRIVE_SPEED},
-                        {{12_in, 24_in}, fwd, DRIVE_SPEED},
-                        {{24_in, 24_in}, fwd, DRIVE_SPEED}},
+  chassis.pid_odom_set({{{0_in, 24_in, 45_deg}, ez::fwd, DRIVE_SPEED},
+                        {{12_in, 24_in}, ez::fwd, DRIVE_SPEED},
+                        {{24_in, 24_in}, ez::fwd, DRIVE_SPEED}},
                        true);
   chassis.pid_wait();
 
-  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, rev, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, ez::rev, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 }
@@ -345,7 +345,7 @@ void measure_offsets() {
     pros::delay(250);
 
     // Calculate delta in angle
-    double t_delta = util::to_rad(fabs(util::wrap_angle(chassis.odom_theta_get() - imu_start)));
+    double t_delta = ez::util::to_rad(fabs(ez::util::wrap_angle(chassis.odom_theta_get() - imu_start)));
 
     // Calculate delta in sensor values that exist
     double l_delta = chassis.odom_tracker_left != nullptr ? chassis.odom_tracker_left->get() : 0.0;

--- a/EZ-Template-Example-Project/src/main.cpp
+++ b/EZ-Template-Example-Project/src/main.cpp
@@ -143,8 +143,8 @@ void screen_print_tracker(ez::tracking_wheel *tracker, std::string name, int lin
   std::string tracker_value = "", tracker_width = "";
   // Check if the tracker exists
   if (tracker != nullptr) {
-    tracker_value = name + " tracker: " + util::to_string_with_precision(tracker->get());             // Make text for the tracker value
-    tracker_width = "  width: " + util::to_string_with_precision(tracker->distance_to_center_get());  // Make text for the distance to center
+    tracker_value = name + " tracker: " + ez::util::to_string_with_precision(tracker->get());             // Make text for the tracker value
+    tracker_width = "  width: " + ez::util::to_string_with_precision(tracker->distance_to_center_get());  // Make text for the distance to center
   }
   ez::screen_print(tracker_value + tracker_width, line);  // Print final tracker text
 }
@@ -163,9 +163,9 @@ void ez_screen_task() {
         // If we're on the first blank page...
         if (ez::as::page_blank_is_on(0)) {
           // Display X, Y, and Theta
-          ez::screen_print("x: " + util::to_string_with_precision(chassis.odom_x_get()) +
-                               "\ny: " + util::to_string_with_precision(chassis.odom_y_get()) +
-                               "\na: " + util::to_string_with_precision(chassis.odom_theta_get()),
+          ez::screen_print("x: " + ez::util::to_string_with_precision(chassis.odom_x_get()) +
+                               "\ny: " + ez::util::to_string_with_precision(chassis.odom_y_get()) +
+                               "\na: " + ez::util::to_string_with_precision(chassis.odom_theta_get()),
                            1);  // Don't override the top Page line
 
           // Display all trackers that are being used
@@ -257,6 +257,6 @@ void opcontrol() {
     // Put more user control code here!
     // . . .
 
-    pros::delay(ez::util::DELAY_TIME);  // This is used for timer calculations!  Keep this ez::util::DELAY_TIME
+    pros::delay(ez::util::DELAY_TIME);  // This is used for timer calculations!  Keep this ez::ez::util::DELAY_TIME
   }
 }

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -20,7 +20,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "pros/motor_group.hpp"
 #include "pros/motors.h"
 
-using namespace ez;
+//using namespace ez;
 
 namespace ez {
 class Drive {

--- a/include/main.h
+++ b/include/main.h
@@ -87,3 +87,10 @@ void opcontrol(void);
 #endif
 
 #endif  // _PROS_MAIN_H_
+
+//#define _USE_EZ_NAMESPACE_ // This is used to include the ez namespace in the main.h file
+
+#ifdef _USE_EZ_NAMESPACE_
+#warning "[EZ-Template] Automatic 'using namespace ez;' from headers is DEPRECATED and will be removed in EZ-Template 4.0. Please use 'ez::' or opt-in manually in your source files."
+using namespace ez;
+#endif

--- a/include/subsystems.hpp
+++ b/include/subsystems.hpp
@@ -3,7 +3,7 @@
 #include "EZ-Template/api.hpp"
 #include "api.h"
 
-extern Drive chassis;
+extern ez::Drive chassis;
 
 // Your motors, sensors, etc. should go here.  Below are examples
 

--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -7,8 +7,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/api.hpp"
 #include "api.h"
 
-using namespace ez;
-
+// using namespace ez;
+namespace ez {
 void PID::variables_reset() {
   output = 0;
   target = 0;
@@ -258,3 +258,4 @@ exit_output PID::exit_condition(pros::MotorGroup sensor, bool print) {
   }
   return exit_condition(vector_sensor, print);
 }
+}  // namespace ez

--- a/src/EZ-Template/auton.cpp
+++ b/src/EZ-Template/auton.cpp
@@ -6,11 +6,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/api.hpp"
 
-Auton::Auton() {
+ez::Auton::Auton() {
   Name = "";
   auton_call = nullptr;
 }
-Auton::Auton(std::string name, std::function<void()> callback) {
+ez::Auton::Auton(std::string name, std::function<void()> callback) {
   Name = name;
   auton_call = callback;
 }

--- a/src/EZ-Template/auton_selector.cpp
+++ b/src/EZ-Template/auton_selector.cpp
@@ -6,32 +6,32 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/api.hpp"
 
-AutonSelector::AutonSelector() {
+ez::AutonSelector::AutonSelector() {
   auton_count = 0;
   auton_page_current = 0;
   Autons = {};
 }
 
-AutonSelector::AutonSelector(std::vector<Auton> autons) {
+ez::AutonSelector::AutonSelector(std::vector<Auton> autons) {
   auton_count = autons.size();
   auton_page_current = 0;
   Autons = {};
   Autons.assign(autons.begin(), autons.end());
 }
 
-void AutonSelector::selected_auton_print() {
+void ez::AutonSelector::selected_auton_print() {
   if (auton_count == 0) return;
   for (int i = 0; i < 8; i++)
     pros::lcd::clear_line(i);
   ez::screen_print("Page " + std::to_string(auton_page_current + 1) + "\n" + Autons[auton_page_current].Name);
 }
 
-void AutonSelector::selected_auton_call() {
+void ez::AutonSelector::selected_auton_call() {
   if (auton_count == 0) return;
   Autons[last_auton_page_current].auton_call();
 }
 
-void AutonSelector::autons_add(std::vector<Auton> autons) {
+void ez::AutonSelector::autons_add(std::vector<Auton> autons) {
   auton_count += autons.size();
   auton_page_current = 0;
   Autons.assign(autons.begin(), autons.end());

--- a/src/EZ-Template/drive/pid_tuner.cpp
+++ b/src/EZ-Template/drive/pid_tuner.cpp
@@ -11,6 +11,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "pros/llemu.hpp"
 #include "pros/misc.h"
 
+namespace ez {
 // Is the PID Tuner enabled?
 bool Drive::pid_tuner_enabled() { return pid_tuner_on; }
 
@@ -210,3 +211,4 @@ void Drive::pid_tuner_iterate() {
     pid_tuner_print();
   }
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/pto.cpp
+++ b/src/EZ-Template/drive/pto.cpp
@@ -9,6 +9,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/drive/drive.hpp"
 
+namespace ez {
 bool Drive::pto_check(pros::Motor check_if_pto) {
   auto does_exist = std::find(pto_active.begin(), pto_active.end(), check_if_pto.get_port());
   if (does_exist != pto_active.end())
@@ -51,3 +52,4 @@ void Drive::pto_toggle(std::vector<pros::Motor> pto_list, bool toggle) {
   else
     pto_remove(pto_list);
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/purepursuit_math.cpp
+++ b/src/EZ-Template/drive/purepursuit_math.cpp
@@ -7,6 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/api.hpp"
 #include "EZ-Template/util.hpp"
 
+namespace ez {
 // Returns a distance that the robot is away from target, but this keeps sign.
 double Drive::is_past_target(pose target, pose current) {
   // Translated current x, y translated around origin
@@ -357,3 +358,4 @@ double Drive::new_turn_target_compute(double target, double current, ez::e_angle
   }
   return new_target;
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
@@ -11,6 +11,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Sets swing constants
 /////
 
+namespace ez {
 // Slew constants
 void Drive::slew_drive_constants_forward_set(okapi::QLength distance, int min_speed) {
   double dist = distance.convert(okapi::inch);
@@ -161,3 +162,4 @@ void Drive::pid_drive_set(double target, int speed, bool slew_on, bool toggle_he
   // Run task
   drive_mode_set(DRIVE);
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -7,6 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/drive/drive.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
+namespace ez {
 /////
 // Set constants
 /////
@@ -492,3 +493,4 @@ void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on) {
   leftPID.exit = xyPID.exit;  // Switch over to xy pid exits
   rightPID.exit = xyPID.exit;
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/set_pid/set_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_pid.cpp
@@ -7,6 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
+namespace ez {
 // Updates max speed
 void Drive::pid_speed_max_set(int speed) {
   max_speed = abs(util::clamp(speed, 127, -127));
@@ -74,3 +75,4 @@ bool Drive::pid_drive_toggle_get() { return drive_toggle; }
 // Don't print stuff
 void Drive::pid_print_toggle(bool toggle) { print_toggle = toggle; }
 bool Drive::pid_print_toggle_get() { return print_toggle; }
+}  // namespace ez

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -7,6 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
+namespace ez {
 /////
 // Sets swing constants
 /////
@@ -352,3 +353,4 @@ void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_s
   // Run task
   drive_mode_set(SWING);
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -7,6 +7,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
+namespace ez {
 /////
 // Sets turn constants
 /////
@@ -195,3 +196,4 @@ void Drive::pid_turn_set(pose itarget, drive_directions dir, int speed, e_angle_
 
   drive_mode_set(TURN_TO_POINT);
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -8,8 +8,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/tracking_wheel.hpp"
 #include "EZ-Template/util.hpp"
 
-using namespace ez;
+// using namespace ez;
 
+namespace ez {
 // Sets and gets
 void Drive::odom_x_set(double x) {
   odom_current.x = x;
@@ -241,3 +242,4 @@ void Drive::ez_tracking_task() {
   // printf("   current used (%.2f, %.2f, %.2f)      l delta: %.2f   r delta: %.2f", odom_current.x, odom_current.y, odom_current.theta, l_, r_);
   // printf("        htw: %f\n", h_track_width);
 }
+}  // namespace ez

--- a/src/EZ-Template/drive/user_input.cpp
+++ b/src/EZ-Template/drive/user_input.cpp
@@ -8,6 +8,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/drive/drive.hpp"
 #include "pros/misc.h"
 
+namespace ez {
 void Drive::opcontrol_arcade_scaling(bool enable) { arcade_vector_scaling = enable; }
 bool Drive::opcontrol_arcade_scaling_enabled() { return arcade_vector_scaling; }
 
@@ -355,3 +356,4 @@ void Drive::opcontrol_arcade_flipped(e_type stick_type) {
   // Set robot to l_stick and r_stick, check joystick threshold, set active brake
   opcontrol_joystick_threshold_iterate(fwd_stick + turn_stick, fwd_stick - turn_stick);
 }
+}  // namespace ez

--- a/src/EZ-Template/piston.cpp
+++ b/src/EZ-Template/piston.cpp
@@ -6,8 +6,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/piston.hpp"
 
-using namespace ez;
+// using namespace ez;
 
+namespace ez {
 // Constructor for one piston
 Piston::Piston(int input_port, bool default_state)
     : piston(input_port, default_state) {
@@ -44,3 +45,4 @@ void Piston::buttons(int active, int deactive) {
   else if (deactive && get())
     set(false);
 }
+}  // namespace ez

--- a/src/EZ-Template/slew.cpp
+++ b/src/EZ-Template/slew.cpp
@@ -6,8 +6,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/api.hpp"
 
-using namespace ez;
+// using namespace ez;
 
+namespace ez {
 // Constructor
 slew::slew() {}
 slew::slew(double distance, int minimum_speed) {
@@ -59,3 +60,4 @@ double slew::iterate(double current) {
 
   return last_output;
 }
+}  // namespace ez

--- a/src/EZ-Template/tracking_wheel.cpp
+++ b/src/EZ-Template/tracking_wheel.cpp
@@ -8,8 +8,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/util.hpp"
 
-using namespace ez;
+// using namespace ez;
 
+namespace ez {
 // ADI Encoder
 tracking_wheel::tracking_wheel(std::vector<int> ports, double wheel_diameter, double distance_to_center, double ratio)
     : adi_encoder(abs(ports[0]), abs(ports[1]), util::reversed_active(ports[0])),
@@ -93,3 +94,4 @@ void tracking_wheel::reset() {
     return;
   }
 }
+}  // namespace ez

--- a/src/EZ-Template/tracking_wheel.cpp
+++ b/src/EZ-Template/tracking_wheel.cpp
@@ -94,4 +94,5 @@ void tracking_wheel::reset() {
     return;
   }
 }
-}  // namespace ez
+}  
+// namespace ez

--- a/src/autons.cpp
+++ b/src/autons.cpp
@@ -15,7 +15,7 @@ const int SWING_SPEED = 110;
 ///
 void default_constants() {
   // P, I, D, and Start I
-  chassis.pid_drive_constants_set(20.0, 0.0, 100.0);         // Fwd/rev constants, used for odom and non odom motions
+  chassis.pid_drive_constants_set(20.0, 0.0, 100.0);         // fwd/rev constants, used for odom and non odom motions
   chassis.pid_heading_constants_set(11.0, 0.0, 20.0);        // Holds the robot straight while going forward without odom
   chassis.pid_turn_constants_set(3.0, 0.05, 20.0, 15.0);     // Turn in place constants
   chassis.pid_swing_constants_set(6.0, 0.0, 65.0);           // Swing constants
@@ -259,14 +259,14 @@ void odom_drive_example() {
 ///
 void odom_pure_pursuit_example() {
   // Drive to 0, 30 and pass through 6, 10 and 0, 20 on the way, with slew
-  chassis.pid_odom_set({{{6_in, 10_in}, fwd, DRIVE_SPEED},
-                        {{0_in, 20_in}, fwd, DRIVE_SPEED},
-                        {{0_in, 30_in}, fwd, DRIVE_SPEED}},
+  chassis.pid_odom_set({{{6_in, 10_in}, ez::fwd, DRIVE_SPEED},
+                        {{0_in, 20_in}, ez::fwd, DRIVE_SPEED},
+                        {{0_in, 30_in}, ez::fwd, DRIVE_SPEED}},
                        true);
   chassis.pid_wait();
 
   // Drive to 0, 0 backwards
-  chassis.pid_odom_set({{0_in, 0_in}, rev, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 0_in}, ez::rev, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 }
@@ -275,9 +275,9 @@ void odom_pure_pursuit_example() {
 // Odom Pure Pursuit Wait Until
 ///
 void odom_pure_pursuit_wait_until_example() {
-  chassis.pid_odom_set({{{0_in, 24_in}, fwd, DRIVE_SPEED},
-                        {{12_in, 24_in}, fwd, DRIVE_SPEED},
-                        {{24_in, 24_in}, fwd, DRIVE_SPEED}},
+  chassis.pid_odom_set({{{0_in, 24_in}, ez::fwd, DRIVE_SPEED},
+                        {{12_in, 24_in}, ez::fwd, DRIVE_SPEED},
+                        {{24_in, 24_in}, ez::fwd, DRIVE_SPEED}},
                        true);
   chassis.pid_wait_until_index(1);  // Waits until the robot passes 12, 24
   // Intake.move(127);  // Set your intake to start moving once it passes through the second point in the index
@@ -289,11 +289,11 @@ void odom_pure_pursuit_wait_until_example() {
 // Odom Boomerang
 ///
 void odom_boomerang_example() {
-  chassis.pid_odom_set({{0_in, 24_in, 45_deg}, fwd, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 24_in, 45_deg}, ez::fwd, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 
-  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, rev, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, ez::rev, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 }
@@ -302,13 +302,13 @@ void odom_boomerang_example() {
 // Odom Boomerang Injected Pure Pursuit
 ///
 void odom_boomerang_injected_pure_pursuit_example() {
-  chassis.pid_odom_set({{{0_in, 24_in, 45_deg}, fwd, DRIVE_SPEED},
-                        {{12_in, 24_in}, fwd, DRIVE_SPEED},
-                        {{24_in, 24_in}, fwd, DRIVE_SPEED}},
+  chassis.pid_odom_set({{{0_in, 24_in, 45_deg}, ez::fwd, DRIVE_SPEED},
+                        {{12_in, 24_in}, ez::fwd, DRIVE_SPEED},
+                        {{24_in, 24_in}, ez::fwd, DRIVE_SPEED}},
                        true);
   chassis.pid_wait();
 
-  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, rev, DRIVE_SPEED},
+  chassis.pid_odom_set({{0_in, 0_in, 0_deg}, ez::rev, DRIVE_SPEED},
                        true);
   chassis.pid_wait();
 }
@@ -345,7 +345,7 @@ void measure_offsets() {
     pros::delay(250);
 
     // Calculate delta in angle
-    double t_delta = util::to_rad(fabs(util::wrap_angle(chassis.odom_theta_get() - imu_start)));
+    double t_delta = ez::util::to_rad(fabs(ez::util::wrap_angle(chassis.odom_theta_get() - imu_start)));
 
     // Calculate delta in sensor values that exist
     double l_delta = chassis.odom_tracker_left != nullptr ? chassis.odom_tracker_left->get() : 0.0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,8 +143,8 @@ void screen_print_tracker(ez::tracking_wheel *tracker, std::string name, int lin
   std::string tracker_value = "", tracker_width = "";
   // Check if the tracker exists
   if (tracker != nullptr) {
-    tracker_value = name + " tracker: " + util::to_string_with_precision(tracker->get());             // Make text for the tracker value
-    tracker_width = "  width: " + util::to_string_with_precision(tracker->distance_to_center_get());  // Make text for the distance to center
+    tracker_value = name + " tracker: " + ez::util::to_string_with_precision(tracker->get());             // Make text for the tracker value
+    tracker_width = "  width: " + ez::util::to_string_with_precision(tracker->distance_to_center_get());  // Make text for the distance to center
   }
   ez::screen_print(tracker_value + tracker_width, line);  // Print final tracker text
 }
@@ -163,9 +163,9 @@ void ez_screen_task() {
         // If we're on the first blank page...
         if (ez::as::page_blank_is_on(0)) {
           // Display X, Y, and Theta
-          ez::screen_print("x: " + util::to_string_with_precision(chassis.odom_x_get()) +
-                               "\ny: " + util::to_string_with_precision(chassis.odom_y_get()) +
-                               "\na: " + util::to_string_with_precision(chassis.odom_theta_get()),
+          ez::screen_print("x: " + ez::util::to_string_with_precision(chassis.odom_x_get()) +
+                               "\ny: " + ez::util::to_string_with_precision(chassis.odom_y_get()) +
+                               "\na: " + ez::util::to_string_with_precision(chassis.odom_theta_get()),
                            1);  // Don't override the top Page line
 
           // Display all trackers that are being used


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Allows the user to remove themselves from the ez namespace - it's now macro-locked in main.h

## Motivation:
<!-- Small explanation of why these changes need to be made -->
Allows easier debugging on uzers, should they choose to use their own namespaces

### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
Closes issue #248 

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
Ensure that everything compiles as normal

- [x] Compiles
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 6c4c7b376922e54c276f7c6f032e40e6619f2d1e -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/18142742546)
- via manual download: [EZ-Template@3.2.2+58a024.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/4147907987.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@3.2.2+58a024.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/4147907987.zip;
pros c fetch EZ-Template@3.2.2+58a024.zip;
pros c apply EZ-Template@3.2.2+58a024;
rm EZ-Template@3.2.2+58a024.zip;
```