### PR TITLE
Fix missing space in docs between motor and name to make clear motor object is one object

### DIFF
--- a/ez-template-docs/tutorials/intake_tutorial.md
+++ b/ez-template-docs/tutorials/intake_tutorial.md
@@ -64,7 +64,7 @@ inline pros::MotorGroup intake({10, -11});  // Negative port will reverse the m
 ## Button Control
 To move a motor we type 
 ```cpp
-motor name.move(a number between -127 and 127);
+motor_name.move(a number between -127 and 127);
 ```
 
 So to make the intake spin at full speed forward, we would type 


### PR DESCRIPTION
## Summary:
<!-- Small description of what you've changed -->
Small change to intake_tutorial.md, add a underscore between `motor` and `name` to remove space.
## Motivation:
<!-- Small explanation of why these changes need to be made -->
Make clear the motor name is one object and placeholder, confused me when I read it.
### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

## Test Plan:
<!-- How should this be tested to ensure the changes work as intended? -->
- [ ] Rebuild website and observe changes.