### PR TITLE
Enhancments for 4.2.2 (Screen rotation, health checks on startup, small fixes)

### DIFF
--- a/include/EZ-Template/api.hpp
+++ b/include/EZ-Template/api.hpp
@@ -10,6 +10,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/auton.hpp"
 #include "EZ-Template/auton_selector.hpp"
 #include "EZ-Template/drive/drive.hpp"
+#include "EZ-Template/display.hpp"
 #include "EZ-Template/piston.hpp"
 #include "EZ-Template/sdcard.hpp"
 #include "EZ-Template/slew.hpp"

--- a/include/EZ-Template/api.hpp
+++ b/include/EZ-Template/api.hpp
@@ -11,6 +11,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "EZ-Template/auton_selector.hpp"
 #include "EZ-Template/drive/drive.hpp"
 #include "EZ-Template/display.hpp"
+#include "EZ-Template/health.hpp"
 #include "EZ-Template/piston.hpp"
 #include "EZ-Template/sdcard.hpp"
 #include "EZ-Template/slew.hpp"

--- a/include/EZ-Template/display.hpp
+++ b/include/EZ-Template/display.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <string>
+
+namespace ez {
+
+/// Rotates the brain screen in 90-degree steps for brains mounted sideways or
+/// upside down. Accepts 0, 90, 180, or 270 (measured clockwise); other values
+/// are rejected with a printed message. Call after the screen is initialized
+/// (ez::as::initialize or pros::lcd::initialize).
+///
+/// At 90 and 270 the stock LLEMU screen is swapped for EZ's portrait screen:
+/// LLEMU builds its widgets at the resolution live when pros::lcd::initialize
+/// ran (480x272), so once the canvas becomes 272x480 its text runs off the
+/// right edge. The portrait screen re-flows the same LLEMU theme, font, print
+/// lines and three-button bar to the rotated resolution, wrapping long lines
+/// rather than clipping them, and replays its button presses onto LLEMU's own
+/// buttons so pros::lcd::register_btn*_cb callbacks behave identically.
+/// 0 and 180 restore LLEMU untouched.
+///
+/// Experimental, unverified on hardware: uses LVGL's software rotation on the
+/// live display driver. Touch rotates with the pixels, so on-screen buttons
+/// respond where they are drawn; LVGL applies that transform to its own
+/// pointer input. 90/270 swap the screen's width and height. The physical
+/// LLEMU buttons are unaffected.
+void screen_rotation_set(int degrees);
+
+/// True while the portrait screen is the loaded screen (rotation 90 or 270).
+bool screen_portrait_enabled();
+
+/// Writes one of the 8 print lines, to the portrait screen when it is loaded
+/// and to LLEMU otherwise. ez::screen_print routes through here.
+void screen_line_set(int line, std::string text);
+
+/// Clears one of the 8 print lines through the same routing as
+/// ez::screen_line_set.
+void screen_line_clear(int line);
+
+/// Clears all 8 print lines through the same routing as ez::screen_line_set.
+void screen_lines_clear();
+
+/// A point in screen coordinates.
+struct screen_point {
+  int x;
+  int y;
+};
+
+/// Maps a raw panel touch into the coordinate space of a screen rotated by
+/// `degrees`. panel_w/panel_h are the physical, unrotated panel size (480x272
+/// on the V5). Unsupported angles pass the point through unchanged.
+///
+/// LVGL already applies this to its own pointer input, so widgets need no help;
+/// this is for code that reads the panel directly (pros::screen_touch_status)
+/// and so bypasses LVGL. Do not apply it to lv_indev data or the point is
+/// transformed twice.
+///
+/// Convention read off the vendored liblvgl.a (LVGL 8.3.4), whose DWARF maps to
+/// lv_refr.c / lv_indev.c / lv_hal_disp.c:
+///   lv_refr.c:1109-1114, 1127-1132 map a rendered area logical -> physical as
+///     90:  px = ly,               py = panel_h - 1 - lx
+///     180: px = panel_w - 1 - lx, py = panel_h - 1 - ly
+///     270: px = panel_w - 1 - ly, py = lx
+///   lv_indev.c:347-354 applies exactly the inverse below to pointer input.
+///   lv_hal_disp.c:349-354 and 372-377 swap hor_res/ver_res on 90 and 270,
+///   leaving the driver's own hor_res/ver_res physical.
+inline screen_point screen_touch_rotate(int degrees, int panel_w, int panel_h, int raw_x, int raw_y) {
+  switch (degrees) {
+    case 90: return {panel_h - 1 - raw_y, raw_x};
+    case 180: return {panel_w - 1 - raw_x, panel_h - 1 - raw_y};
+    case 270: return {raw_y, panel_w - 1 - raw_x};
+    default: return {raw_x, raw_y};
+  }
+}
+
+/// Current rotation in degrees (0, 90, 180, or 270).
+int screen_rotation_get();
+
+}  // namespace ez

--- a/include/EZ-Template/health.hpp
+++ b/include/EZ-Template/health.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "EZ-Template/drive/drive.hpp"
+#include "pros/device.hpp"
+#include "pros/misc.hpp"
+
+namespace ez {
+namespace health {
+
+struct Report {
+  bool imu_ok = true;
+  int motors_bad = 0;    ///< drive motors not responding
+  int trackers_bad = 0;  ///< configured odom trackers not responding
+  int devices_bad = 0;   ///< registered devices not responding
+  bool all_ok() const {
+    return imu_ok && motors_bad == 0 && trackers_bad == 0 && devices_bad == 0;
+  }
+};
+
+/// Checks that the IMU, every drive motor, every configured odom tracker, and
+/// every device registered with device_add() responds. Prints each failure with
+/// its port and rumbles the controller when anything is wrong. Safe to call
+/// from initialize() and again at the start of autonomous.
+Report preflight(ez::Drive& chassis, pros::Controller& controller);
+
+/// Registers a smart device (a motor that isn't on the drive, a distance,
+/// rotation, or optical sensor, anything deriving from pros::Device) for
+/// inclusion in preflight checks. A null device is ignored, and a null name is
+/// reported as "unnamed device".
+void device_add(pros::Device* device, const char* name);
+
+}  // namespace health
+}  // namespace ez

--- a/include/EZ-Template/health.hpp
+++ b/include/EZ-Template/health.hpp
@@ -10,8 +10,12 @@ namespace health {
 struct Report {
   bool imu_ok = true;
   int motors_bad = 0;    ///< drive motors not responding
+  int motors_hot = 0;    ///< drive motors hot enough to be losing power
+  int motors_warm = 0;   ///< drive motors warm but still at full power
   int trackers_bad = 0;  ///< configured odom trackers not responding
   int devices_bad = 0;   ///< registered devices not responding
+  /// Temperature is a warning rather than a failure, so motors_hot and
+  /// motors_warm deliberately do not count against this.
   bool all_ok() const {
     return imu_ok && motors_bad == 0 && trackers_bad == 0 && devices_bad == 0;
   }
@@ -28,6 +32,15 @@ Report preflight(ez::Drive& chassis, pros::Controller& controller);
 /// inclusion in preflight checks. A null device is ignored, and a null name is
 /// reported as "unnamed device".
 void device_add(pros::Device* device, const char* name);
+
+/// Adds a "Health Check" page to the auton selector, so preflight can be run
+/// from the brain instead of from code. Call this in initialize(), after
+/// ez::as::initialize().
+///
+/// This is only a convenience: preflight() is an ordinary function, so calling
+/// it from an opcontrol button works just as well, e.g.
+/// `if (master.get_digital_new_press(DIGITAL_Y)) ez::health::preflight(chassis, master);`
+void preflight_register(ez::Drive& chassis);
 
 }  // namespace health
 }  // namespace ez

--- a/src/EZ-Template/auton_selector.cpp
+++ b/src/EZ-Template/auton_selector.cpp
@@ -22,7 +22,7 @@ ez::AutonSelector::AutonSelector(std::vector<Auton> autons) {
 void ez::AutonSelector::selected_auton_print() {
   if (auton_count == 0) return;
   for (int i = 0; i < 8; i++)
-    pros::lcd::clear_line(i);
+    ez::screen_line_clear(i);
   ez::screen_print("Page " + std::to_string(auton_page_current + 1) + "\n" + Autons[auton_page_current].Name);
 }
 

--- a/src/EZ-Template/display.cpp
+++ b/src/EZ-Template/display.cpp
@@ -6,6 +6,7 @@
 #include "liblvgl/llemu.hpp"
 #include "liblvgl/lvgl.h"
 #include "pros/llemu.hpp"
+#include "pros/rtos.hpp"
 
 #if LVGL_VERSION_MAJOR >= 9
 // For lv_display_t::flush_cb and buf_1: LVGL 9 has no getter for the installed
@@ -229,6 +230,66 @@ void flush_wrapper_install(lv_display_t* disp) {
   g_flush_orig = disp->flush_cb;
   lv_display_set_flush_cb(disp, flush_rotated_cb);
 }
+
+// The kernel's display daemon runs lv_timer_handler with no lock at all: this
+// liblvgl is built with LV_USE_OS none, so its lv_lock is empty, and the cold
+// package links the archive whole, so a replacement here can't reach it. lvgl
+// 8 tolerated other tasks writing labels anyway; lvgl 9 asserts the moment
+// lv_inv_area runs while a frame is mid-render, and the assert handler never
+// returns, taking the writing task -- and with it the daemon and LLEMU's
+// buttons -- down for good. Blank pages redraw through the screen task every
+// iteration, so landing on one made that near-certain. The print lines are
+// buffered instead and replayed from the daemon itself, riding the touch
+// indev's read callback because that is the only call the daemon makes every
+// cycle that library code can reach; installing the wrapper is a single
+// function-pointer store, so it can't tear mid-swap.
+bool g_line_dirty[LINE_COUNT] = {false};
+lv_indev_read_cb_t g_indev_read_orig = nullptr;
+
+// Function-local so the screen task can print at static-init time without
+// racing this file's own construction.
+pros::Mutex& line_mutex() {
+  static pros::Mutex mutex;
+  return mutex;
+}
+
+// Runs on the display daemon's task, where label writes are safe.
+void lines_replay(lv_indev_t* indev, lv_indev_data_t* data) {
+  g_indev_read_orig(indev, data);
+
+  // Left dirty until LLEMU exists so nothing prints into null labels.
+  if (!g_portrait_on && !pros::lcd::is_initialized()) return;
+
+  for (int i = 0; i < LINE_COUNT; i++) {
+    line_mutex().take();
+    bool dirty = g_line_dirty[i];
+    std::string text = g_line_text[i];
+    g_line_dirty[i] = false;
+    line_mutex().give();
+    if (!dirty) continue;
+
+    if (g_portrait_on)
+      portrait_line_set(i, text.c_str());
+    else
+      pros::lcd::set_text(i, text);
+  }
+}
+
+void screen_line_publish(int line, std::string text) {
+  line_mutex().take();
+  g_line_text[line] = text;
+  g_line_dirty[line] = true;
+
+  if (g_indev_read_orig == nullptr) {
+    lv_indev_t* indev = lv_indev_get_next(nullptr);
+    lv_indev_read_cb_t orig = indev != nullptr ? lv_indev_get_read_cb(indev) : nullptr;
+    if (orig != nullptr && orig != lines_replay) {
+      g_indev_read_orig = orig;
+      lv_indev_set_read_cb(indev, lines_replay);
+    }
+  }
+  line_mutex().give();
+}
 }  // namespace
 
 void screen_rotation_set(int degrees) {
@@ -272,6 +333,17 @@ namespace {
 void portrait_load() {}
 void portrait_unload() {}
 void portrait_line_set(int line, const char* text) {}
+
+// LVGL 8 has no rendering_in_progress assert, so writes go straight through
+// here; only the LVGL 9 build has to marshal them onto the display daemon.
+void screen_line_publish(int line, std::string text) {
+  g_line_text[line] = text;
+
+  // The global screen task starts printing at static-init time, before LLEMU
+  // exists.
+  if (!pros::lcd::is_initialized()) return;
+  pros::lcd::set_text(line, text);
+}
 }  // namespace
 
 void screen_rotation_set(int degrees) {
@@ -314,38 +386,17 @@ int screen_rotation_get() { return g_rotation; }
 bool screen_portrait_enabled() { return g_portrait_on; }
 
 void screen_line_set(int line, std::string text) {
-  if (line >= 0 && line < LINE_COUNT) g_line_text[line] = text;
-
-  if (g_portrait_on) {
-    if (line >= 0 && line < LINE_COUNT) portrait_line_set(line, text.c_str());
-    return;
-  }
-  // The global screen task starts printing at static-init time, before LLEMU
-  // exists; under lvgl 9 touching its null labels corrupts the heap.
-  if (!pros::lcd::is_initialized()) return;
-  pros::lcd::set_text(line, text);
+  if (line < 0 || line >= LINE_COUNT) return;
+  screen_line_publish(line, text);
 }
 
 void screen_line_clear(int line) {
-  if (line >= 0 && line < LINE_COUNT) g_line_text[line].clear();
-
-  if (g_portrait_on) {
-    if (line >= 0 && line < LINE_COUNT) portrait_line_set(line, "");
-    return;
-  }
-  if (!pros::lcd::is_initialized()) return;
-  pros::lcd::clear_line(line);
+  if (line < 0 || line >= LINE_COUNT) return;
+  screen_line_publish(line, "");
 }
 
 void screen_lines_clear() {
-  for (int i = 0; i < LINE_COUNT; i++) g_line_text[i].clear();
-
-  if (g_portrait_on) {
-    for (int i = 0; i < LINE_COUNT; i++) portrait_line_set(i, "");
-    return;
-  }
-  if (!pros::lcd::is_initialized()) return;
-  pros::lcd::clear();
+  for (int i = 0; i < LINE_COUNT; i++) screen_line_publish(i, "");
 }
 
 }  // namespace ez

--- a/src/EZ-Template/display.cpp
+++ b/src/EZ-Template/display.cpp
@@ -1,0 +1,351 @@
+#include "EZ-Template/display.hpp"
+
+#include <cstdint>
+#include <cstdio>
+
+#include "liblvgl/llemu.hpp"
+#include "liblvgl/lvgl.h"
+#include "pros/llemu.hpp"
+
+#if LVGL_VERSION_MAJOR >= 9
+// For lv_display_t::flush_cb and buf_1: LVGL 9 has no getter for the installed
+// flush callback, and the rotation wrapper below needs to save the kernel's.
+#include "liblvgl/display/lv_display_private.h"
+#include "liblvgl/draw/sw/lv_draw_sw.h"
+#endif
+
+namespace ez {
+
+namespace {
+constexpr int LINE_COUNT = 8;
+
+int g_rotation = 0;
+bool g_portrait_on = false;
+std::string g_line_text[LINE_COUNT];
+}  // namespace
+
+#if LVGL_VERSION_MAJOR >= 9
+
+namespace {
+// Read out of the vendored liblvgl.a (llemu.c.o, lcd_initialize) so the
+// portrait screen is LLEMU's theme at a different size, not a lookalike. LLEMU
+// was rewritten against the LVGL 9 API on this kernel, but every color it sets
+// is unchanged from the LVGL 8 build; COL_TEXT doubles as the button fill,
+// which LLEMU names COL_BTN_NORMAL.
+constexpr uint32_t COL_SCREEN = 0x404040;
+constexpr uint32_t COL_FRAME = 0x808080;
+constexpr uint32_t COL_PANEL_BORDER = 0x606060;
+constexpr uint32_t COL_PANEL = 0x5ABC03;
+constexpr uint32_t COL_TEXT = 0x202020;
+constexpr uint32_t COL_BAR = 0xA0A0A0;
+constexpr uint32_t COL_BTN_PRESSED = 0x808080;
+
+// LLEMU's own dimensions: 8 labels on an 18px pitch, each 14px narrower than
+// its panel, in a 30px tall button bar of three 80px buttons.
+constexpr int32_t LINE_PITCH = 18;
+constexpr int32_t PANEL_INSET = 14;
+constexpr int32_t BAR_HEIGHT = 30;
+constexpr int32_t BTN_WIDTH = 76;
+constexpr int32_t MARGIN = 11;
+
+lv_obj_t* g_portrait_screen = nullptr;
+lv_obj_t* g_portrait_lines[LINE_COUNT] = {nullptr};
+lv_obj_t* g_llemu_screen = nullptr;
+
+lv_obj_t* llemu_button_search(lv_obj_t* parent, int index, int& found) {
+  uint32_t children = lv_obj_get_child_count(parent);
+  for (uint32_t i = 0; i < children; i++) {
+    lv_obj_t* child = lv_obj_get_child(parent, i);
+    if (lv_obj_check_type(child, &lv_button_class)) {
+      if (found == index) return child;
+      found++;
+      continue;
+    }
+    lv_obj_t* match = llemu_button_search(child, index, found);
+    if (match != nullptr) return match;
+  }
+  return nullptr;
+}
+
+// LLEMU's three buttons are the only lv_button objects it builds, in btn0/btn1/
+// btn2 order. Resolved per click rather than cached because pros::lcd::shutdown
+// deletes the tree they live in.
+lv_obj_t* llemu_button_get(int index) {
+  if (g_llemu_screen == nullptr) return nullptr;
+  int found = 0;
+  return llemu_button_search(g_llemu_screen, index, found);
+}
+
+// Replays the press onto LLEMU's own button so whatever is registered through
+// pros::lcd::register_btn*_cb runs with the context it already expects,
+// including the center button EZ leaves to the user.
+void portrait_button_cb(lv_event_t* event) {
+  lv_event_code_t code = lv_event_get_code(event);
+  if (code != LV_EVENT_PRESSED && code != LV_EVENT_RELEASED && code != LV_EVENT_CLICKED) return;
+
+  lv_obj_t* target = llemu_button_get((int)(intptr_t)lv_event_get_user_data(event));
+  if (target != nullptr) lv_obj_send_event(target, code, nullptr);
+}
+
+void portrait_create() {
+  int32_t w = lv_display_get_horizontal_resolution(nullptr);
+  int32_t h = lv_display_get_vertical_resolution(nullptr);
+  int32_t panel_w = w - (MARGIN * 2);
+  int32_t panel_h = h - BAR_HEIGHT - (MARGIN * 4);
+
+  g_portrait_screen = lv_obj_create(nullptr);
+  lv_obj_set_size(g_portrait_screen, w, h);
+  lv_obj_set_style_pad_all(g_portrait_screen, 0, 0);
+  lv_obj_set_scrollbar_mode(g_portrait_screen, LV_SCROLLBAR_MODE_OFF);
+  lv_obj_remove_flag(g_portrait_screen, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_bg_color(g_portrait_screen, lv_color_hex(COL_SCREEN), 0);
+
+  lv_obj_t* frame = lv_obj_create(g_portrait_screen);
+  lv_obj_set_size(frame, w, h);
+  lv_obj_set_style_pad_all(frame, 0, 0);
+  lv_obj_remove_flag(frame, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_bg_color(frame, lv_color_hex(COL_FRAME), 0);
+  lv_obj_set_style_border_color(frame, lv_color_hex(COL_FRAME), 0);
+
+  lv_obj_t* panel = lv_obj_create(frame);
+  lv_obj_set_size(panel, panel_w, panel_h);
+  lv_obj_align(panel, LV_ALIGN_TOP_MID, 0, MARGIN);
+  lv_obj_set_style_pad_all(panel, 2, 0);
+  lv_obj_set_style_pad_left(panel, 7, 0);
+  lv_obj_set_style_pad_row(panel, 0, 0);
+  lv_obj_remove_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(panel, LV_SCROLLBAR_MODE_OFF);
+  lv_obj_set_style_border_color(panel, lv_color_hex(COL_PANEL_BORDER), 0);
+  lv_obj_set_style_bg_color(panel, lv_color_hex(COL_PANEL), 0);
+  lv_obj_set_style_text_color(panel, lv_color_hex(COL_TEXT), 0);
+  lv_obj_set_style_text_font(panel, &pros_font_dejavu_mono_18, 0);
+  // LLEMU pins each label to a fixed y; the wrapped lines have to push the ones
+  // under them down instead, which is what the extra height is for.
+  lv_obj_set_flex_flow(panel, LV_FLEX_FLOW_COLUMN);
+
+  for (int i = 0; i < LINE_COUNT; i++) {
+    lv_obj_t* label = lv_label_create(panel);
+    lv_obj_set_width(label, panel_w - PANEL_INSET);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+    // Empty labels collapse to nothing under flex, so hold LLEMU's pitch.
+    lv_obj_set_style_min_height(label, LINE_PITCH, 0);
+    lv_label_set_text(label, "");
+    g_portrait_lines[i] = label;
+  }
+
+  lv_obj_t* bar = lv_obj_create(frame);
+  lv_obj_set_size(bar, panel_w, BAR_HEIGHT);
+  lv_obj_align(bar, LV_ALIGN_BOTTOM_MID, 0, -MARGIN);
+  lv_obj_set_style_bg_color(bar, lv_color_hex(COL_BAR), 0);
+  lv_obj_set_style_border_color(bar, lv_color_hex(COL_FRAME), 0);
+  lv_obj_set_style_border_width(bar, 0, 0);
+  lv_obj_set_style_pad_all(bar, 0, 0);
+  lv_obj_set_flex_flow(bar, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(bar, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+  lv_obj_remove_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+
+  for (int i = 0; i < 3; i++) {
+    lv_obj_t* btn = lv_button_create(bar);
+    lv_obj_set_width(btn, BTN_WIDTH);
+    lv_obj_add_event_cb(btn, portrait_button_cb, LV_EVENT_ALL, (void*)(intptr_t)i);
+    lv_obj_set_style_bg_color(btn, lv_color_hex(COL_TEXT), 0);
+    lv_obj_set_style_bg_color(btn, lv_color_hex(COL_BTN_PRESSED), LV_STATE_PRESSED);
+  }
+}
+
+// Screens are built and loaded from whatever task calls screen_rotation_set,
+// while PROS's disp_daemon is already inside lv_timer_handler; the load-time
+// full-screen repaint races that flush and lands only partly on a rotated
+// display. Repainting once more from a timer puts the redraw on the daemon's
+// own task, where nothing is in flight.
+void repaint_schedule() {
+  lv_timer_t* timer = lv_timer_create([](lv_timer_t* t) { lv_obj_invalidate(lv_screen_active()); }, 60, nullptr);
+  lv_timer_set_repeat_count(timer, 1);
+}
+
+void portrait_load() {
+  if (g_portrait_screen == nullptr) portrait_create();
+
+  if (!g_portrait_on) {
+    g_llemu_screen = lv_screen_active();
+    g_portrait_on = true;
+  }
+
+  for (int i = 0; i < LINE_COUNT; i++)
+    lv_label_set_text(g_portrait_lines[i], g_line_text[i].c_str());
+
+  lv_screen_load(g_portrait_screen);
+  repaint_schedule();
+}
+
+void portrait_unload() {
+  if (!g_portrait_on) return;
+
+  g_portrait_on = false;
+  // The portrait screen is kept, not deleted, so repeated calls reuse it.
+  if (g_llemu_screen != nullptr) lv_screen_load(g_llemu_screen);
+  repaint_schedule();
+}
+
+void portrait_line_set(int line, const char* text) { lv_label_set_text(g_portrait_lines[line], text); }
+
+// LVGL 9 dropped core software rotation: lv_display_set_rotation only re-lays
+// out widgets, and rotating the pixels became the flush driver's job. The
+// kernel's driver (lvgl_display_flush in liblvgl's display.c) just copies
+// px_map to the panel at the area's own coordinates, so a rotated screen
+// renders correctly but displays unrotated. This wrapper slots in front of it:
+// each flushed band is software-rotated into physical orientation and its area
+// remapped from logical to panel coordinates before the kernel's flush runs.
+// Pointer input needs no counterpart; lv_indev.c already rotates touch points
+// off the display's rotation.
+lv_display_flush_cb_t g_flush_orig = nullptr;
+uint8_t* g_flush_rotated = nullptr;
+
+void flush_rotated_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map) {
+  lv_display_rotation_t rot = lv_display_get_rotation(disp);
+  if (rot == LV_DISPLAY_ROTATION_0) {
+    g_flush_orig(disp, area, px_map);
+    return;
+  }
+
+  int32_t w = lv_area_get_width(area);
+  int32_t h = lv_area_get_height(area);
+  lv_color_format_t cf = lv_display_get_color_format(disp);
+  int32_t px_size = lv_color_format_get_size(cf);
+  // 90 and 270 land the band on its side, so the destination rows are h wide.
+  int32_t dest_w = rot == LV_DISPLAY_ROTATION_180 ? w : h;
+  lv_draw_sw_rotate(px_map, g_flush_rotated, w, h, w * px_size, dest_w * px_size, rot, cf);
+
+  lv_area_t rotated = *area;
+  lv_display_rotate_area(disp, &rotated);
+  g_flush_orig(disp, &rotated, g_flush_rotated);
+}
+
+void flush_wrapper_install(lv_display_t* disp) {
+  if (g_flush_orig != nullptr) return;
+  // A rotated band holds exactly as many pixels as the flushed one, so the
+  // draw buffer's own size is the worst case.
+  g_flush_rotated = new uint8_t[disp->buf_1->data_size];
+  g_flush_orig = disp->flush_cb;
+  lv_display_set_flush_cb(disp, flush_rotated_cb);
+}
+}  // namespace
+
+void screen_rotation_set(int degrees) {
+  lv_display_rotation_t rot;
+  switch (degrees) {
+    case 0:   rot = LV_DISPLAY_ROTATION_0; break;
+    case 90:  rot = LV_DISPLAY_ROTATION_90; break;
+    case 180: rot = LV_DISPLAY_ROTATION_180; break;
+    case 270: rot = LV_DISPLAY_ROTATION_270; break;
+    default:
+      printf("[display] Invalid rotation %d; use 0, 90, 180, or 270.\n", degrees);
+      return;
+  }
+
+  lv_display_t* disp = lv_display_get_default();
+  if (disp == nullptr) {
+    printf("[display] No LVGL display yet; initialize the screen first.\n");
+    return;
+  }
+  // Installed before the rotation takes effect so no rotated band is ever
+  // flushed through the kernel's unrotated path. At 0 it passes through, so
+  // it is left in place once installed.
+  if (rot != LV_DISPLAY_ROTATION_0) flush_wrapper_install(disp);
+  lv_display_set_rotation(disp, rot);
+  g_rotation = degrees;
+
+  // Built after the rotation so the screen picks up the swapped resolution.
+  if (degrees == 90 || degrees == 270)
+    portrait_load();
+  else
+    portrait_unload();
+
+  printf("[display] Screen rotation set to %d degrees.\n", degrees);
+}
+
+#else  // LVGL 8
+
+namespace {
+// The portrait screen is built against the LVGL 9 API, so on LVGL 8 every
+// rotation keeps stock LLEMU and the print lines route to it unchanged.
+void portrait_load() {}
+void portrait_unload() {}
+void portrait_line_set(int line, const char* text) {}
+}  // namespace
+
+void screen_rotation_set(int degrees) {
+  lv_disp_rot_t rot;
+  switch (degrees) {
+    case 0:   rot = LV_DISP_ROT_NONE; break;
+    case 90:  rot = LV_DISP_ROT_90; break;
+    case 180: rot = LV_DISP_ROT_180; break;
+    case 270: rot = LV_DISP_ROT_270; break;
+    default:
+      printf("[display] Invalid rotation %d; use 0, 90, 180, or 270.\n", degrees);
+      return;
+  }
+
+  lv_disp_t* disp = lv_disp_get_default();
+  if (disp == nullptr || disp->driver == nullptr) {
+    printf("[display] No LVGL display yet; initialize the screen first.\n");
+    return;
+  }
+  // No indev hook here: LVGL 8.3.4 already rotates pointer input off
+  // disp->driver->rotated (lv_indev.c:347-354, inlined into
+  // lv_indev_read_timer_cb in the vendored liblvgl.a). Wrapping read_cb with
+  // ez::screen_touch_rotate would transform the point a second time.
+  disp->driver->sw_rotate = 1;
+  lv_disp_set_rotation(disp, rot);
+  g_rotation = degrees;
+
+  if (degrees == 90 || degrees == 270)
+    portrait_load();
+  else
+    portrait_unload();
+
+  printf("[display] Screen rotation set to %d degrees.\n", degrees);
+}
+
+#endif
+
+int screen_rotation_get() { return g_rotation; }
+
+bool screen_portrait_enabled() { return g_portrait_on; }
+
+void screen_line_set(int line, std::string text) {
+  if (line >= 0 && line < LINE_COUNT) g_line_text[line] = text;
+
+  if (g_portrait_on) {
+    if (line >= 0 && line < LINE_COUNT) portrait_line_set(line, text.c_str());
+    return;
+  }
+  // The global screen task starts printing at static-init time, before LLEMU
+  // exists; under lvgl 9 touching its null labels corrupts the heap.
+  if (!pros::lcd::is_initialized()) return;
+  pros::lcd::set_text(line, text);
+}
+
+void screen_line_clear(int line) {
+  if (line >= 0 && line < LINE_COUNT) g_line_text[line].clear();
+
+  if (g_portrait_on) {
+    if (line >= 0 && line < LINE_COUNT) portrait_line_set(line, "");
+    return;
+  }
+  if (!pros::lcd::is_initialized()) return;
+  pros::lcd::clear_line(line);
+}
+
+void screen_lines_clear() {
+  for (int i = 0; i < LINE_COUNT; i++) g_line_text[i].clear();
+
+  if (g_portrait_on) {
+    for (int i = 0; i < LINE_COUNT; i++) portrait_line_set(i, "");
+    return;
+  }
+  if (!pros::lcd::is_initialized()) return;
+  pros::lcd::clear();
+}
+
+}  // namespace ez

--- a/src/EZ-Template/health.cpp
+++ b/src/EZ-Template/health.cpp
@@ -1,5 +1,6 @@
 #include "EZ-Template/health.hpp"
 
+#include "EZ-Template/api.hpp"
 #include "pros/error.h"
 #include <cstdio>
 #include <utility>
@@ -10,6 +11,12 @@ namespace health {
 
 namespace {
 std::vector<std::pair<pros::Device*, const char*>> g_devices;
+
+// The v5 firmware cuts motor power in stages as a motor heats up, the first of
+// them at 55C, so a motor at or above that is already down on torque. 45C is an
+// early warning: still at full power, but on its way there.
+constexpr double MOTOR_TEMP_HOT_C = 55.0;
+constexpr double MOTOR_TEMP_WARM_C = 45.0;
 }
 
 void device_add(pros::Device* device, const char* name) {
@@ -27,9 +34,21 @@ Report preflight(ez::Drive& chassis, pros::Controller& controller) {
 
   auto check_motors = [&](std::vector<pros::Motor>& motors) {
     for (auto& m : motors) {
-      if (m.get_temperature() == PROS_ERR_F) {
+      // An error return means nothing is answering on the port at all, which is
+      // reported on its own so a dead motor never picks up a temperature line
+      // as well. The temperature tiers below are a separate, softer concern.
+      double temp = m.get_temperature();
+      if (temp == PROS_ERR_F) {
         r.motors_bad++;
         printf("[health] Drive motor on port %d not responding\n", m.get_port());
+        continue;
+      }
+      if (temp >= MOTOR_TEMP_HOT_C) {
+        r.motors_hot++;
+        printf("[health] Drive motor on port %d is overheating (%.0fC) - v5 throttles at 55\n", m.get_port(), temp);
+      } else if (temp >= MOTOR_TEMP_WARM_C) {
+        r.motors_warm++;
+        printf("[health] Drive motor on port %d is getting warm (%.0fC)\n", m.get_port(), temp);
       }
     }
   };
@@ -65,7 +84,31 @@ Report preflight(ez::Drive& chassis, pros::Controller& controller) {
   } else {
     printf("[health] Preflight OK.\n");
   }
+
+  // Temperature never fails the preflight, so this trails the verdict above and
+  // only rumbles when that verdict passed, since a failure already buzzed "---".
+  if (r.motors_hot > 0 || r.motors_warm > 0) {
+    printf("[health] temp watch: %d hot, %d warm\n", r.motors_hot, r.motors_warm);
+    if (r.all_ok()) controller.rumble(".");
+  }
   return r;
+}
+
+void preflight_register(ez::Drive& chassis) {
+  ez::Drive* drive = &chassis;
+
+  // The selector's autons_add() assigns over the list instead of appending, so
+  // the page is pushed on directly to leave any autons already added alone.
+  as::auton_selector.Autons.push_back(
+      Auton("Health Check\n\nRuns preflight",
+            [drive]() {
+              pros::Controller controller(pros::E_CONTROLLER_MASTER);
+              preflight(*drive, controller);
+            }));
+  as::auton_selector.auton_count++;
+
+  printf("[health] Health Check registered on selector page %d.\n",
+         (int)as::auton_selector.Autons.size());
 }
 
 }  // namespace health

--- a/src/EZ-Template/health.cpp
+++ b/src/EZ-Template/health.cpp
@@ -1,0 +1,72 @@
+#include "EZ-Template/health.hpp"
+
+#include "pros/error.h"
+#include <cstdio>
+#include <utility>
+#include <vector>
+
+namespace ez {
+namespace health {
+
+namespace {
+std::vector<std::pair<pros::Device*, const char*>> g_devices;
+}
+
+void device_add(pros::Device* device, const char* name) {
+  if (device == nullptr) return;
+  g_devices.push_back({device, name != nullptr ? name : "unnamed device"});
+}
+
+Report preflight(ez::Drive& chassis, pros::Controller& controller) {
+  Report r;
+
+  if (chassis.imu == nullptr || !chassis.imu->is_installed()) {
+    r.imu_ok = false;
+    printf("[health] IMU on port %d not responding\n", chassis.imu != nullptr ? chassis.imu->get_port() : -1);
+  }
+
+  auto check_motors = [&](std::vector<pros::Motor>& motors) {
+    for (auto& m : motors) {
+      if (m.get_temperature() == PROS_ERR_F) {
+        r.motors_bad++;
+        printf("[health] Drive motor on port %d not responding\n", m.get_port());
+      }
+    }
+  };
+  check_motors(chassis.left_motors);
+  check_motors(chassis.right_motors);
+
+  auto check_tracker = [&](ez::tracking_wheel* t, const char* name) {
+    if (t == nullptr) return;
+    if (t->get_raw() == PROS_ERR_F || t->get_raw() == PROS_ERR) {
+      r.trackers_bad++;
+      printf("[health] %s tracker not responding\n", name);
+    }
+  };
+  check_tracker(chassis.odom_tracker_left, "left");
+  check_tracker(chassis.odom_tracker_right, "right");
+  check_tracker(chassis.odom_tracker_front, "front");
+  check_tracker(chassis.odom_tracker_back, "back");
+
+  for (auto& [dev, name] : g_devices) {
+    // is_installed() compares what's actually plugged into the port against the
+    // type the device was constructed as, so an empty port and a port holding
+    // the wrong kind of device both read as not installed
+    if (!dev->is_installed()) {
+      r.devices_bad++;
+      printf("[health] \"%s\" (port %d) not responding\n", name, dev->get_port());
+    }
+  }
+
+  if (!r.all_ok()) {
+    controller.rumble("---");
+    printf("[health] PREFLIGHT FAILED: imu %s, %d motor(s), %d tracker(s), %d device(s)\n",
+           r.imu_ok ? "ok" : "BAD", r.motors_bad, r.trackers_bad, r.devices_bad);
+  } else {
+    printf("[health] Preflight OK.\n");
+  }
+  return r;
+}
+
+}  // namespace health
+}  // namespace ez

--- a/src/EZ-Template/sdcard.cpp
+++ b/src/EZ-Template/sdcard.cpp
@@ -9,6 +9,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <filesystem>
 
 #include "auton_selector.hpp"
+#include "display.hpp"
 #include "liblvgl/llemu.hpp"
 #include "pros/llemu.hpp"
 #include "util.hpp"
@@ -58,7 +59,7 @@ void print_page() {
     auton_selector.selected_auton_print();
   } else {
     for (int i = 0; i < 8; i++)
-      pros::lcd::clear_line(i);
+      ez::screen_line_clear(i);
     screen_print("Page " + std::to_string(auton_selector.auton_page_current + 1) + " - Blank page " + std::to_string(page_blank_current() + 1));
   }
   if (page_blank_current() < 0)

--- a/src/EZ-Template/util.cpp
+++ b/src/EZ-Template/util.cpp
@@ -54,12 +54,6 @@ std::string get_rest_of_the_word(std::string text, int position) {
 }
 
 void screen_print(std::string text, int line) {
-  // The example project's global screen task starts printing during static
-  // init, before ez::as::initialize creates LLEMU. lvgl 8 tolerated writing to
-  // the null labels; lvgl 9 walks the null object's parent chain and corrupts
-  // the heap, so drop the print until the screen exists.
-  if (!pros::lcd::is_initialized()) return;
-
   int CurrAutoLine = line;
   std::vector<string> texts = {};
   std::string temp = "";
@@ -99,12 +93,12 @@ void screen_print(std::string text, int line) {
   }
   for (auto i : texts) {
     if (CurrAutoLine > 7) {
-      pros::lcd::clear();
-      pros::lcd::set_text(line, "Out of Bounds. Print Line is too far down");
+      screen_lines_clear();
+      screen_line_set(line, "Out of Bounds. Print Line is too far down");
       return;
     }
-    pros::lcd::clear_line(CurrAutoLine);
-    pros::lcd::set_text(CurrAutoLine, i);
+    screen_line_clear(CurrAutoLine);
+    screen_line_set(CurrAutoLine, i);
     CurrAutoLine++;
   }
 }


### PR DESCRIPTION
**Features:**

- screen rotation — ez::screen_rotation_set(90) for sideways/upside-down brain mounts. at 90/270 the selector rebuilds as a portrait copy of the llemu screen (same thing, lines wrap instead of clipping, buttons are smaller). lvgl 9 dropped built-in rotation, so the flush path software-rotates each rendered band onto the panel. touch works at every angle to my knowledge
- health checks — ez::health::preflight(chassis, master) pings the imu, every drive motor, odom trackers, and any device registered with ez::health::device_add(&intake, "name"). It prints each disconnected or device in the wrong port.
- other small fixes, and a LVGL 9 fix

**References (optional):**
follows #320
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 105918bead3e3e7ca5d3e4d39ffb8f8caa0b49d6 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/32914384096)
- via manual download: [EZ-Template@4.0.0+b25ac4.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9587604902.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+b25ac4.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9587604902.zip;
pros c fetch EZ-Template@4.0.0+b25ac4.zip;
pros c apply EZ-Template@4.0.0+b25ac4;
rm EZ-Template@4.0.0+b25ac4.zip;
```