### PR TITLE
🐛Fix integral reset comparing error against position

### DIFF
--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -85,7 +85,7 @@ double PID::raw_compute() {
       integral += error;
 
     // Reset i when the sign of error flips
-    if (util::sgn(error) != util::sgn(prev_current) && reset_i_sgn)
+    if (util::sgn(error) != util::sgn(prev_error) && reset_i_sgn)
       integral = 0;
   }
 


### PR DESCRIPTION
## Summary:
One line in `PID::raw_compute()`. The sign flip integral reset was comparing `sgn(error)` against `sgn(prev_current)`. Changed it back to `sgn(prev_error)`.

```diff
-    if (util::sgn(error) != util::sgn(prev_current) && reset_i_sgn)
+    if (util::sgn(error) != util::sgn(prev_error) && reset_i_sgn)
       integral = 0;
```

## Motivation:
The comment directly above that line says "Reset i when the sign of error flips", but `prev_current` is the previous sensor position, not the previous error. Those are unrelated quantities, so the condition was not testing what it claims to test.

On a normal move to a positive target, `prev_current` stays positive for nearly the entire motion while error is also positive, so the reset never fires. The moment the robot crosses the target, error flips negative while position stays positive, so the reset then fires on every single tick. The net effect is integral windup that never clears on the approach, followed by the integral being wiped every tick during the settle. That is the opposite of the intended behavior in both phases.

This is a regression from 576eb32, which refactored the derivative term onto measurement instead of error. That change correctly needed `prev_current` for the derivative, and the substitution carried one line too far into the integral block.

Supporting evidence that it was accidental rather than deliberate. `prev_error` is declared in `PID.hpp`, zeroed in `variables_reset()`, and assigned at the end of `raw_compute()`, but it is read nowhere in the codebase. It has been dead since 576eb32. This line is the only thing it exists for.

### References (optional):
Regression introduced in 576eb32 (#105).

## Test Plan:
- [ ] Set a nonzero `ki` and `start_i` on the drive PID, print `integral` each tick
- [ ] Drive to a target and confirm `integral` accumulates on the approach and zeroes once on crossing the target, rather than never zeroing
- [ ] Confirm it does not zero on every tick during the settle
- [ ] Run an existing auton with integral enabled and confirm settling is no worse than before
- [ ] Confirm `i_reset_toggle(false)` still disables the reset entirely

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: eaa5a13f73f21a88e42a93c8a6527f06e3d4a774 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025134863)
- via manual download: [EZ-Template@4.0.0+eaa5a1.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986796749.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+eaa5a1.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986796749.zip;
pros c fetch EZ-Template@4.0.0+eaa5a1.zip;
pros c apply EZ-Template@4.0.0+eaa5a1;
rm EZ-Template@4.0.0+eaa5a1.zip;
```