### PR TITLE
🐛Fix big exit time never running

### DIFF
--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -155,7 +155,7 @@ exit_output PID::exit_condition(bool print) {
 
   // If the robot is close to the target, start a timer.  If the robot doesn't get closer within
   // a certain amount of time, exit and continue.  This does not run while small_timeout is running
-  else if (exit.big_error != 0 && exit.big_exit_time != 0) {  // Check if this condition is enabled
+  if (exit.big_error != 0 && exit.big_exit_time != 0) {  // Check if this condition is enabled
     if (abs(error) < exit.big_error) {
       i += util::DELAY_TIME;
       if (i > exit.big_exit_time) {


### PR DESCRIPTION
## Summary:
One line in `PID::exit_condition()`. Changed the `else if` on the big error check to a plain `if` so the big exit timer is actually reachable.

```diff
-  else if (exit.big_error != 0 && exit.big_exit_time != 0) {  // Check if this condition is enabled
+  if (exit.big_error != 0 && exit.big_exit_time != 0) {  // Check if this condition is enabled
```

## Motivation:
The big error branch was chained as an `else if` off the small error check, which means it only ran when `small_error` was 0. Nearly every configuration sets a small error, so in practice the entire big exit branch was dead code and `big_exit_time` did nothing at all. Moves that should have timed out and continued would instead sit there until the velocity or mA exit caught them.

The `i = 0` line inside the small branch, commented "While this is running, don't run big thresh", already handles the mutual exclusion between the two timers. That line only makes sense if the big branch is reachable on the same tick, which the `else` prevented. So the `else` was both redundant and breaking.

Behavior after the fix, traced per tick. While inside small error, `i` is zeroed and then immediately incremented by one delay period, so it never accumulates and cannot trip. Once outside small error but inside big error, `i` accumulates normally and the big exit fires as documented.

This is a regression from d844c96, which changed this from an `if` to an `else if` as part of an unrelated unit conversion fix.

**Heads up for reviewers.** This is a real behavior change, not a no op. Anyone who tuned autons while big exit was silently dead will now see some moves exit earlier than they used to. That is the documented and intended behavior, and a 4.0.0 beta is the right place to restore it, but it should not be a surprise.

### References (optional):
Regression introduced in d844c96.

## Test Plan:
- [ ] Set `small_error`, `big_error`, and `big_exit_time` to normal values
- [ ] Block the robot just outside `small_error` but inside `big_error` and confirm `BIG EXIT` prints after `big_exit_time`
- [ ] Confirm the same case before this change hangs until velocity or mA exit instead
- [ ] Confirm `SMALL EXIT` still fires normally on an unobstructed move, and that big exit does not fire early during the settle
- [ ] Confirm a config with `big_error` or `big_exit_time` set to 0 still skips the branch entirely
- [ ] Run a full auton and check that no move exits noticeably earlier than intended

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 98928ddd60cd9a58451edf59f97a54438fe59adc -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025127704)
- via manual download: [EZ-Template@4.0.0+98928d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986794451.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+98928d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986794451.zip;
pros c fetch EZ-Template@4.0.0+98928d.zip;
pros c apply EZ-Template@4.0.0+98928d;
rm EZ-Template@4.0.0+98928d.zip;
```