### PR TITLE
🐛Qualify abs() as std::fabs() on doubles

### DIFF
--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -4,6 +4,8 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <cmath>
+
 #include "EZ-Template/api.hpp"
 #include "api.h"
 
@@ -140,7 +142,7 @@ exit_output PID::exit_condition(bool print) {
 
   // If the robot gets within the target, make sure it's there for small_timeout amount of time
   if (exit.small_error != 0) {
-    if (abs(error) < exit.small_error) {
+    if (std::fabs(error) < exit.small_error) {
       j += util::DELAY_TIME;
       i = 0;  // While this is running, don't run big thresh
       if (j > exit.small_exit_time) {
@@ -156,7 +158,7 @@ exit_output PID::exit_condition(bool print) {
   // If the robot is close to the target, start a timer.  If the robot doesn't get closer within
   // a certain amount of time, exit and continue.  This does not run while small_timeout is running
   else if (exit.big_error != 0 && exit.big_exit_time != 0) {  // Check if this condition is enabled
-    if (abs(error) < exit.big_error) {
+    if (std::fabs(error) < exit.big_error) {
       i += util::DELAY_TIME;
       if (i > exit.big_exit_time) {
         timers_reset();
@@ -170,7 +172,7 @@ exit_output PID::exit_condition(bool print) {
 
   // If the motor velocity is 0, the code will timeout and set interfered to true.
   if (exit.velocity_exit_time != 0) {  // Check if this condition is enabled
-    if (abs(derivative) <= velocity_zero_main) {
+    if (std::fabs(derivative) <= velocity_zero_main) {
       k += util::DELAY_TIME;
       if (k > exit.velocity_exit_time) {
         timers_reset();
@@ -187,7 +189,7 @@ exit_output PID::exit_condition(bool print) {
 
   // If the secondary sensors velocity is 0, the code will timeout and set interfered to true.
   if (exit.velocity_exit_time != 0) {  // Check if this condition is enabled
-    if (abs(second_sensor) <= velocity_zero_secondary) {
+    if (std::fabs(second_sensor) <= velocity_zero_secondary) {
       m += util::DELAY_TIME;
       if (m > exit.velocity_exit_time) {
         timers_reset();

--- a/src/EZ-Template/drive/purepursuit_math.cpp
+++ b/src/EZ-Template/drive/purepursuit_math.cpp
@@ -4,6 +4,8 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <cmath>
+
 #include "EZ-Template/api.hpp"
 #include "EZ-Template/util.hpp"
 
@@ -236,7 +238,7 @@ std::vector<odom> Drive::smooth_path(std::vector<odom> ipath, double weight_smoo
           y_i += weight_data * (x_i - y_i) + weight_smooth * (y_next + y_prev - (2.0 * y_i));
           new_path[i][j] = y_i;
 
-          change += abs(y_i - y_i_saved);
+          change += std::fabs(y_i - y_i_saved);
         }
       }
     }

--- a/src/EZ-Template/drive/set_pid/set_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_pid.cpp
@@ -4,13 +4,15 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <cmath>
+
 #include "EZ-Template/api.hpp"
 #include "okapi/api/units/QAngle.hpp"
 
 namespace ez {
 // Updates max speed
 void Drive::pid_speed_max_set(int speed) {
-  max_speed = abs(util::clamp(speed, 127, -127));
+  max_speed = std::fabs(util::clamp(speed, 127, -127));
   slew_left.speed_max_set(max_speed);
   slew_right.speed_max_set(max_speed);
   slew_turn.speed_max_set(max_speed);


### PR DESCRIPTION
## Summary:
Six call sites pass a `double` to an unqualified `abs()`. Changed each to `std::fabs()` and added `#include <cmath>` to the three files.

`PID.cpp` L143, L159, L173, L190 · `set_pid.cpp` L13 · `purepursuit_math.cpp` L239

## Motivation:
Unqualified `abs()` on a `double` is only correct here by accident. `auton_selector.hpp` has a global `using namespace std;`, and `api.hpp` pulls it in, which is what makes `std::abs(double)` visible at these call sites. Include `PID.hpp` on its own, without `api.hpp`, and the same expressions resolve to `int abs(int)` and truncate.

If that happens, the failures are quiet and nasty. `abs(derivative)` truncates to 0 for anything slower than 100 in/s, so the velocity exit fires 500 ms into every motion. `abs(error)` under 1.0 becomes 0, so the small exit fires instantly.

Nothing changes in the current build. This is a hardening change that makes the intent explicit, so the `using namespace std;` in a public header can be removed later without silently breaking every exit condition. That removal should be a separate PR.

## Test Plan:
- [ ] Build the template and confirm it compiles clean with no new warnings
- [ ] Confirm behavior is unchanged, since this should be a no op today
- [ ] Optional and the real point of the change, temporarily remove `using namespace std;` from `auton_selector.hpp` and confirm the library still builds and exits behave the same

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: ff9c56af691a41ff0734fd981064250607213967 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34067753007)
- via manual download: [EZ-Template@4.0.0+ff9c56.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9999479049.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+ff9c56.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9999479049.zip;
pros c fetch EZ-Template@4.0.0+ff9c56.zip;
pros c apply EZ-Template@4.0.0+ff9c56;
rm EZ-Template@4.0.0+ff9c56.zip;
```