### PR TITLE
🐛Stop pid_wait_until_index from indexing out of range

### DIFF
--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -395,8 +395,10 @@ void Drive::pid_wait_until_index_started(int index) {
   // Let the PID run at least 1 iteration
   pros::delay(util::DELAY_TIME);
 
-  if (index > injected_pp_index.size() - 2 || index < 0)
-    printf("  Wait Until PP Error!  Index %i is not within range!  %i is max!\n", index, injected_pp_index.size() - 2);
+  if (index < 0 || index > (int)injected_pp_index.size() - 2) {
+    printf("  Wait Until PP Error!  Index %i is not within range!  %i is max!\n", index, (int)injected_pp_index.size() - 2);
+    return;
+  }
   index += 1;
 
   exit_output xy_exit = RUNNING;
@@ -423,6 +425,7 @@ void Drive::pid_wait_until_index_started(int index) {
 void Drive::pid_wait_until_index(int index) {
   pid_wait_until_index_started(index);
   index += 1;
+  if (index < 0 || index >= (int)injected_pp_index.size()) return;
   pose target = pp_movements[injected_pp_index[index]].target;
   pid_wait_until_point(target);
 }


### PR DESCRIPTION
## Summary:
`pid_wait_until_index_started` detected an out of range index, printed an error, and then used it anyway. Added the missing `return`, fixed a signed/unsigned comparison, and added a bounds guard in `pid_wait_until_index`.

## Motivation:
Three separate problems in the same place.

**The check has no `return`.** It prints "Index is not within range" and then falls straight through to `index += 1` and `injected_pp_index[index]`, so the error message is a warning about undefined behavior that is about to happen anyway.

**The comparison is signed against unsigned.** `index > injected_pp_index.size() - 2` promotes `index` to `size_t`. On a path with 0 or 1 injected points, `size() - 2` wraps to a huge value and the check never fires at all. The `%i` in the printf was also formatting a `size_t`.

**`pid_wait_until_index` has no check of its own.** It increments the index a second time and dereferences both `injected_pp_index` and `pp_movements` with no bounds test.

An off by one in a team's auton is easy to make with these indices, and today it reads past two vectors and then waits on garbage instead of printing something useful and moving on.

## Test Plan:
- [ ] Call `pid_wait_until_index()` with an index past the end of the path and confirm the error prints once and the call returns instead of waiting
- [ ] Call it with a negative index and confirm the same
- [ ] Run a path with fewer than 2 injected points and confirm the guard fires rather than wrapping
- [ ] Confirm a valid index still waits and exits exactly as before

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 2f95202de0d95f294fcbbcd30eae1f558adb91c0 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025139627)
- via manual download: [EZ-Template@4.0.0+f9ed5c.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798428.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+f9ed5c.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798428.zip;
pros c fetch EZ-Template@4.0.0+f9ed5c.zip;
pros c apply EZ-Template@4.0.0+f9ed5c;
rm EZ-Template@4.0.0+f9ed5c.zip;
```