### PR TITLE
🐛Fix turn direction debug prints and a self-include

### DIFF
--- a/include/EZ-Template/util.hpp
+++ b/include/EZ-Template/util.hpp
@@ -14,7 +14,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "okapi/api/units/QAngle.hpp"
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/QTime.hpp"
-#include "util.hpp"
 
 using namespace okapi::literals;
 

--- a/src/EZ-Template/drive/purepursuit_math.cpp
+++ b/src/EZ-Template/drive/purepursuit_math.cpp
@@ -304,6 +304,7 @@ double Drive::turn_left(double target, double current, bool print) {
   if (util::sgn(shortest - current) == -1) {
     output = shortest;
 
+    if (print) printf("%.2f\n", output);
     return output;
   }
 
@@ -316,12 +317,13 @@ double Drive::turn_left(double target, double current, bool print) {
 
 // Always turn right
 double Drive::turn_right(double target, double current, bool print) {
-  if (print) printf("LEFT   Target: %.2f   Current: %.2f      New Target: ", target, current);
+  if (print) printf("RIGHT  Target: %.2f   Current: %.2f      New Target: ", target, current);
   double shortest = util::turn_shortest(target, current, false);
   double output = shortest;
   if (util::sgn(shortest - current) == 1) {
     output = shortest;
 
+    if (print) printf("%.2f\n", output);
     return output;
   }
 


### PR DESCRIPTION
## Summary:
Two unrelated one liners, both cosmetic, grouped because neither can affect runtime behavior.

`turn_right()` printed `LEFT`. Both `turn_left()` and `turn_right()` returned early on the shortest path without printing the value they chose. And `util.hpp` included itself.

## Motivation:
The debug print in `turn_right` says LEFT, so anyone reading the log while debugging a turn direction sees the wrong label on every line.

Worse, both functions print the `New Target: ` prefix, then hit the early `return output;` on the shortest path branch without ever printing the number. The output is a dangling prefix with no value, and it only completes on the longest path branch. So the print is broken in exactly the common case someone would be using it to inspect.

`util.hpp` including `util.hpp` is harmless today thanks to `#pragma once`, but it resolves by search path, so it is one `-I` flag away from including a user's own `util.hpp` instead.

Diagnostics and headers only. No motion behavior changes.

## Test Plan:
- [ ] Call `pid_turn_set` with `ez::cw` and `ez::ccw` and print toggled on, and confirm the log now reads `RIGHT` for right turns and `LEFT` for left turns
- [ ] Confirm every printed line now ends with the chosen target value rather than a dangling prefix
- [ ] Confirm the library still builds after removing the self include

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 2d8c5c30d84af9c8d70723a11500d168ac9ec4a4 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025137723)
- via manual download: [EZ-Template@4.0.0+2d8c5c.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798023.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+2d8c5c.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798023.zip;
pros c fetch EZ-Template@4.0.0+2d8c5c.zip;
pros c apply EZ-Template@4.0.0+2d8c5c;
rm EZ-Template@4.0.0+2d8c5c.zip;
```