### PR TITLE
🐛Use the magnitude of IMU acceleration, not x plus y

### DIFF
--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -4,6 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <cmath>
 #include <list>
 
 #include "EZ-Template/api.hpp"
@@ -421,7 +422,10 @@ void Drive::drive_imu_reset(double new_heading) {
 double Drive::get_this_imu(pros::Imu* imu) { return imu->get_rotation() * imu_scale_map[imu->get_port()]; }
 
 double Drive::drive_imu_get() { return get_this_imu(imu); }
-double Drive::drive_imu_accel_get() { return imu->get_accel().x + imu->get_accel().y; }
+double Drive::drive_imu_accel_get() {
+  auto accel = imu->get_accel();
+  return std::hypot(accel.x, accel.y);
+}
 
 void Drive::drive_imu_scaler_set(double scaler) { imu_scale_map[imu->get_port()] = scaler; }
 double Drive::drive_imu_scaler_get() { return imu_scale_map[imu->get_port()]; }


### PR DESCRIPTION
## Summary:
`drive_imu_accel_get()` returned `accel.x + accel.y`. Changed to `std::hypot(accel.x, accel.y)`, and it now reads `get_accel()` once instead of twice.

## Motivation:
Adding two perpendicular components is not a magnitude. Whenever `x` and `y` are equal and opposite they cancel, so a robot accelerating along a 45 degree diagonal reports 0 acceleration while it is very much accelerating.

That value feeds the secondary velocity exit through `velocity_sensor_secondary_set(drive_imu_accel_get())`, so the exit sees a stationary robot and fires mid motion. Any diagonal odom move is a candidate.

Reading `get_accel()` twice also meant two separate device reads for one value, from different instants.

**Note for reviewers.** This does change behavior for anyone relying on the secondary velocity exit, in that it now reports a real non negative magnitude instead of a signed sum that could be near zero or negative. Motions that were exiting early on diagonals will stop doing that, which is the point, but it is a real change.

## Test Plan:
- [ ] Print `drive_imu_accel_get()` while pushing the robot along +x, +y, and a 45 degree diagonal, and confirm all three read non zero
- [ ] Confirm the diagonal case reads roughly the vector magnitude rather than near zero
- [ ] Run an odom motion that travels diagonally and confirm it no longer trips the secondary velocity exit early
- [ ] Confirm straight line motions exit the same as before

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 5e6e7dd36499cc992b4235b124f8901be89e8b8c -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025138664)
- via manual download: [EZ-Template@4.0.0+5e6e7d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798013.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+5e6e7d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798013.zip;
pros c fetch EZ-Template@4.0.0+5e6e7d.zip;
pros c apply EZ-Template@4.0.0+5e6e7d;
rm EZ-Template@4.0.0+5e6e7d.zip;
```