### PR TITLE
🐛Make drive_imu_reset respect the IMU scaler

### DIFF
--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -413,7 +413,11 @@ bool Drive::drive_current_left_over() { return left_motors.front().is_over_curre
 
 void Drive::drive_imu_reset(double new_heading) {
   for (int i = 0; i < good_imus.size(); i++) {
-    good_imus[i]->set_rotation(new_heading);
+    // Reads go through get_this_imu(), which multiplies by the scaler, so the
+    // value written here has to be divided by it to read back as new_heading
+    auto scaler = imu_scale_map.find(good_imus[i]->get_port());
+    double scale = (scaler != imu_scale_map.end() && scaler->second != 0.0) ? scaler->second : 1.0;
+    good_imus[i]->set_rotation(new_heading / scale);
   }
   angle_rad = util::to_rad(new_heading);
   t_last = angle_rad;


### PR DESCRIPTION
## Summary:
`drive_imu_reset()` wrote `set_rotation(new_heading)` without accounting for the IMU scaler that every read multiplies by. Now divides by the scaler on write.

## Motivation:
Reads go through `get_this_imu()`, which returns `get_rotation() * imu_scale_map[port]`. Writes did not divide by it. So with a scaler of 1.01, `odom_xyt_set(0, 0, 90)` stores 90 and reads back 90.9, and every absolute turn afterwards is off by the scaler times the start heading. The error is proportional to the heading you reset to, which is why it is invisible at heading 0, where the template does all of its resets.

Two details in the implementation.

Uses `find()` rather than `operator[]`, so a heading reset no longer inserts map entries as a side effect of reading them.

Falls back to `1.0` when an IMU has no scaler entry. That is a real case, not defensive padding. `drive_imus_scalers_set` loops to `std::min(good_imus.size(), scales.size())`, so passing fewer scalers than IMUs leaves the remainder absent from the map, and `operator[]` would default construct them to `0.0`. Dividing by that would be a crash, and multiplying by it on read is a separate existing bug worth its own issue.

No effect on the default configuration, where the constructors call `drive_imu_scaler_set(1)`.

## Test Plan:
- [ ] With no scaler set, confirm `odom_xyt_set(0, 0, 90)` then `drive_angle_get()` reads 90, unchanged from before
- [ ] Set a scaler of 1.01, call `odom_xyt_set(0, 0, 90)`, and confirm `drive_angle_get()` reads 90 rather than 90.9
- [ ] Confirm an absolute turn after a non zero heading reset lands where asked
- [ ] With multiple IMUs and fewer scalers than IMUs, confirm no divide by zero and no crash

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3ce02a1e85bf9e5af18e551f7f33d5725db3f6e8 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025137685)
- via manual download: [EZ-Template@4.0.0+fcea5e.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986797666.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+fcea5e.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986797666.zip;
pros c fetch EZ-Template@4.0.0+fcea5e.zip;
pros c apply EZ-Template@4.0.0+fcea5e;
rm EZ-Template@4.0.0+fcea5e.zip;
```