### PR TITLE
🐛Return the real constants from pid_drive/swing_constants_get

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
@@ -66,6 +66,11 @@ PID::Constants Drive::pid_heading_constants_get() { return headingPID.constants_
 PID::Constants Drive::pid_drive_constants_backward_get() { return backward_drivePID.constants_get(); }
 PID::Constants Drive::pid_drive_constants_forward_get() { return forward_drivePID.constants_get(); }
 PID::Constants Drive::pid_drive_constants_get() {
+  // The plain setter zeroes forward/backward and stores the constants in fwd_rev,
+  // so return those rather than the zeros they were replaced with
+  if (!forward_drivePID.constants_set_check() && !backward_drivePID.constants_set_check())
+    return fwd_rev_drivePID.constants_get();
+
   auto fwd_const = pid_drive_constants_forward_get();
   auto rev_const = pid_drive_constants_backward_get();
   if (!(fwd_const.kp == rev_const.kp && fwd_const.ki == rev_const.ki && fwd_const.kd == rev_const.kd && fwd_const.start_i == rev_const.start_i)) {

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -30,6 +30,11 @@ void Drive::pid_swing_constants_backward_set(double p, double i, double d, doubl
 PID::Constants Drive::pid_swing_constants_forward_get() { return forward_swingPID.constants_get(); }
 PID::Constants Drive::pid_swing_constants_backward_get() { return backward_swingPID.constants_get(); }
 PID::Constants Drive::pid_swing_constants_get() {
+  // The plain setter zeroes forward/backward and stores the constants in fwd_rev,
+  // so return those rather than the zeros they were replaced with
+  if (!forward_swingPID.constants_set_check() && !backward_swingPID.constants_set_check())
+    return fwd_rev_swingPID.constants_get();
+
   auto fwd_const = pid_swing_constants_forward_get();
   auto rev_const = pid_swing_constants_backward_get();
   if (!(fwd_const.kp == rev_const.kp && fwd_const.ki == rev_const.ki && fwd_const.kd == rev_const.kd && fwd_const.start_i == rev_const.start_i)) {


### PR DESCRIPTION
## Summary:
`pid_drive_constants_get()` and `pid_swing_constants_get()` returned `0/0/0/0` in the default configuration. They now fall back to the `fwd_rev` PID when neither directional PID has constants set.

## Motivation:
`pid_drive_constants_set()` zeroes `forward_drivePID` and `backward_drivePID` and stores the real constants in `fwd_rev_drivePID`. The getter only ever looked at forward and backward. It compared them, found them equal because both were zero, took that as agreement, and returned the zeros.

So for anyone using the plain setter, which is the default path and what `default_constants()` uses, the getter reports 0/0/0/0. Printing or logging your constants shows zeros. Worse, the save-change-restore pattern, where you read the constants, set something temporary for one motion, then write the saved values back, restores zeros and silently disables the PID for the rest of the auton.

`pid_swing_constants_get()` has the identical shape and the identical bug.

The fix uses the existing `PID::constants_set_check()` helper, which already means "are any of these four non zero". When neither directional PID has constants, the constants must be in `fwd_rev`, so return those. The forward/backward mismatch warning is untouched for configurations that do use the directional setters.

## Test Plan:
- [ ] Call `pid_drive_constants_set(20, 0, 100)` then `pid_drive_constants_get()` and confirm it returns 20/0/100 rather than zeros
- [ ] Same for `pid_swing_constants_set` and `pid_swing_constants_get`
- [ ] Set forward and backward separately to different values and confirm the mismatch warning still prints and `-1, -1, -1, -1` is still returned
- [x] Set forward and backward to identical values and confirm the getter returns them
- [ ] Read constants, change them, restore from the saved value, and confirm the drive still moves

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 9f1723e1aac7e14d6f9f604c67359120775a3842 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025140463)
- via manual download: [EZ-Template@4.0.0+9321ff.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798743.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+9321ff.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986798743.zip;
pros c fetch EZ-Template@4.0.0+9321ff.zip;
pros c apply EZ-Template@4.0.0+9321ff;
rm EZ-Template@4.0.0+9321ff.zip;
```