### PR TITLE
🐛Define PID::name_get() and remove the unused timing fields

### DIFF
--- a/include/EZ-Template/PID.hpp
+++ b/include/EZ-Template/PID.hpp
@@ -279,8 +279,6 @@ class PID {
   double prev_current = 0.0;
   double integral = 0.0;
   double derivative = 0.0;
-  long time = 0;
-  long prev_time = 0;
 
  private:
   double velocity_zero_main = 0.05;

--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -15,8 +15,6 @@ void PID::variables_reset() {
   error = 0;
   prev_error = 0;
   integral = 0;
-  time = 0;
-  prev_time = 0;
 }
 
 PID::PID() {
@@ -110,6 +108,8 @@ void PID::name_set(std::string p_name) {
   name = p_name;
   name_active = name == "" ? false : true;
 }
+
+std::string PID::name_get() { return name; }
 
 void PID::exit_condition_print(ez::exit_output exit_type) {
   std::cout << " ";


### PR DESCRIPTION
## Summary:
Defines `PID::name_get()`, which was declared and never implemented, and removes the unused `time` and `prev_time` members.

## Motivation:
**`name_get()` does not exist.** `PID.hpp` L247 declares `std::string name_get();` and no translation unit defines it. It builds fine because nothing in the library calls it, so the first team to call it on their own PID gets an undefined reference at link time with no obvious cause. Defined next to `name_set()`, returning `name`.

**`time` and `prev_time` are dead.** Both were intended to hold timestamps so the derivative could be computed against real elapsed time instead of assuming a fixed loop period, which would make the D term independent of any jitter in the brain's scheduling. That was never implemented. Both are zeroed in `variables_reset()` and read by nothing.

Removing them rather than leaving them, since a field that looks like it carries timing information but is permanently 0 is worse than no field. If loop period drift ever turns out to matter, a real `dt` aware derivative is worth doing deliberately and it should not inherit two stale members to build on.

**One note for review.** `time` and `prev_time` sat above the `private:` specifier, so they were public. Removing them is technically a source-breaking change. In practice anything reading them was reading a constant 0, and a major version is the right place to drop them, but it is a public symbol removal rather than pure internal cleanup.

## Test Plan:
- [ ] Build the library and confirm it compiles clean
- [ ] Call `name_get()` from user code on a named PID and confirm it links and returns the name set by `name_set()`
- [ ] Confirm it returns an empty string on a PID that was never named
- [ ] Confirm PID behavior is otherwise unchanged, since nothing read the removed fields

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 1514a782af17401eb879ac0d96b85c05bd88d5fa -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34025383803)
- via manual download: [EZ-Template@4.0.0+1514a7.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986874117.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+1514a7.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/9986874117.zip;
pros c fetch EZ-Template@4.0.0+1514a7.zip;
pros c apply EZ-Template@4.0.0+1514a7;
rm EZ-Template@4.0.0+1514a7.zip;
```