### PR TITLE
[H6] Fix swing behavior parameter being ignored in two overloads

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -238,7 +238,7 @@ void Drive::pid_swing_relative_set(e_swing type, okapi::QAngle p_target, int spe
 /////
 // Absolute
 void Drive::pid_swing_set(e_swing type, double target, int speed, e_angle_behavior behavior, bool slew_on) {
-  pid_swing_set(type, target, speed, 0, pid_swing_behavior_get(), slew_on);
+  pid_swing_set(type, target, speed, 0, behavior, slew_on);
 }
 void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, e_angle_behavior behavior, bool slew_on) {
   double target = p_target.convert(okapi::degree);  // Convert okapi unit to degree
@@ -249,7 +249,7 @@ void Drive::pid_swing_relative_set(e_swing type, double target, int speed, e_ang
   // Compute absolute target by adding to current heading
   double absolute_target = headingPID.target_get() + target;
   if (print_toggle) printf("Relative ");
-  pid_swing_set(type, absolute_target, speed, 0, pid_swing_behavior_get(), slew_on);
+  pid_swing_set(type, absolute_target, speed, 0, behavior, slew_on);
 }
 void Drive::pid_swing_relative_set(e_swing type, okapi::QAngle p_target, int speed, e_angle_behavior behavior, bool slew_on) {
   double target = p_target.convert(okapi::degree);  // Convert okapi unit to degree


### PR DESCRIPTION
Two overloads in src/EZ-Template/drive/set_pid/set_swing_pid.cpp take an explicit e_angle_behavior behavior parameter but their bodies called pid_swing_behavior_get() instead of forwarding that parameter to the base pid_swing_set call, silently discarding the caller's choice of angle behavior in favor of the globally configured default.

The fix changes the 5th argument in the inner pid_swing_set call within pid_swing_set(e_swing, double, int, e_angle_behavior, bool) and within pid_swing_relative_set(e_swing, double, int, e_angle_behavior, bool) from pid_swing_behavior_get() to the behavior parameter that was already being passed in. No other overloads were touched; the many other call sites in this file that legitimately use pid_swing_behavior_get() (because they do not accept a behavior parameter at all) are unchanged.

Verified with a clean pros make build from this worktree: all EZ-Template sources compiled successfully, the cold and hot packages linked without errors, and set_swing_pid.cpp itself compiled OK. Also confirmed via git diff origin/dev...HEAD that the change touches only the two intended lines.

Audit ID: H6
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 94b82dbcc726921c97266c192e6a2d53eb0380cc -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34070276101)
- via manual download: [EZ-Template@4.0.0+94b82d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000215415.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+94b82d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000215415.zip;
pros c fetch EZ-Template@4.0.0+94b82d.zip;
pros c apply EZ-Template@4.0.0+94b82d;
rm EZ-Template@4.0.0+94b82d.zip;
```