### PR TITLE
[M15] Fix MotorGroup exit_condition clobbering the big-exit timer

### DIFF
--- a/include/EZ-Template/PID.hpp
+++ b/include/EZ-Template/PID.hpp
@@ -221,7 +221,7 @@ class PID {
    * \param print = false
    *        if true, prints when complete
    */
-  ez::exit_output exit_condition(std::vector<pros::Motor> sensor, bool print = false);
+  ez::exit_output exit_condition(const std::vector<pros::Motor>& sensor, bool print = false);
 
   /**
    * Iterative exit condition for PID.
@@ -231,7 +231,7 @@ class PID {
    * \param print = false
    *        if true, prints when complete
    */
-  ez::exit_output exit_condition(pros::MotorGroup sensor, bool print = false);
+  ez::exit_output exit_condition(const pros::MotorGroup& sensor, bool print = false);
 
   /**
    * Sets the name of the PID that prints during exit conditions.

--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -224,7 +224,7 @@ exit_output PID::exit_condition(pros::Motor sensor, bool print) {
   return exit_condition(print);
 }
 
-exit_output PID::exit_condition(std::vector<pros::Motor> sensor, bool print) {
+exit_output PID::exit_condition(const std::vector<pros::Motor>& sensor, bool print) {
   // If the motors are pulling too many mA, the code will timeout and set interfered to true.
   if (exit.mA_timeout != 0) {  // Check if this condition is enabled
     for (auto i : sensor) {
@@ -253,10 +253,10 @@ exit_output PID::exit_condition(std::vector<pros::Motor> sensor, bool print) {
   return exit_condition(print);
 }
 
-exit_output PID::exit_condition(pros::MotorGroup sensor, bool print) {
+exit_output PID::exit_condition(const pros::MotorGroup& sensor, bool print) {
   std::vector<pros::Motor> vector_sensor;
-  for (i = 0; i < sensor.size(); i++) {
-    vector_sensor.push_back(pros::Motor(sensor.get_port(i)));
+  for (int n = 0; n < sensor.size(); n++) {
+    vector_sensor.push_back(pros::Motor(sensor.get_port(n)));
   }
   return exit_condition(vector_sensor, print);
 }


### PR DESCRIPTION
PID::exit_condition(pros::MotorGroup sensor, bool print) reused the class's private member i as the loop counter while converting the MotorGroup into a vector of Motor objects. That same i is the big-exit timer accumulated in PID::exit_condition(bool print), so every call through this MotorGroup overload reset i back down to the motor count and the big-exit timer could never accumulate past that reset, meaning big-exit could never fire for a MotorGroup-driven mechanism.

The fix declares a local loop variable (n) in the MotorGroup overload instead of touching the member i, so the big-exit timer accumulates normally across calls. While making this change, the sensor parameters on this overload and on the std::vector<pros::Motor> overload it calls into were also changed from pass-by-value to const reference, since both only read from sensor and the previous signatures caused an unnecessary vector copy plus heap allocation on every call in the 10ms exit-condition wait loop.

Verified with a full from-scratch pros make build in a fresh worktree: it completed cleanly with no new warnings, producing bin/cold.package.elf and bin/hot.package.bin. Also reasoned through and grepped all call sites of exit_condition in src/EZ-Template/drive/exit_conditions.cpp to confirm the const-reference signature change is transparent to every caller (brace-init temporaries and existing lvalue arguments both bind fine).

Audit ID: M15
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: b9fad62e022fad6d2c8740e310b23c670c9c9810 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34070835233)
- via manual download: [EZ-Template@4.0.0+b9fad6.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000385587.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+b9fad6.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000385587.zip;
pros c fetch EZ-Template@4.0.0+b9fad6.zip;
pros c apply EZ-Template@4.0.0+b9fad6;
rm EZ-Template@4.0.0+b9fad6.zip;
```