### PR TITLE
[H8] Fix stack corruption in Drive::smooth_path from fixed-size arrays

### DIFF
--- a/src/EZ-Template/drive/purepursuit_math.cpp
+++ b/src/EZ-Template/drive/purepursuit_math.cpp
@@ -4,7 +4,9 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <array>
 #include <cmath>
+#include <vector>
 
 #include "EZ-Template/api.hpp"
 #include "EZ-Template/util.hpp"
@@ -178,8 +180,10 @@ std::vector<odom> Drive::inject_points(std::vector<ez::odom> imovements) {
 
 // Path smoothing based on https://medium.com/@jaems33/understanding-robot-motion-path-smoothing-5970c8363bc4
 std::vector<odom> Drive::smooth_path(std::vector<odom> ipath, double weight_smooth, double weight_data, double tolerance) {
-  double path[500][3];
-  double new_path[500][3];
+  if (ipath.size() < 3) return ipath;
+
+  std::vector<std::array<double, 3>> path(ipath.size());
+  std::vector<std::array<double, 3>> new_path(ipath.size());
   std::vector<bool> dont_touch;
   int t = 0;
   bool allow_injecting = false;


### PR DESCRIPTION
Drive::smooth_path used fixed 500-row stack arrays (path, new_path) indexed by ipath.size() with no bounds check, so a path longer than about 250 points at the default 0.5 in spacing wrote past the end of the arrays and corrupted the stack. Separately, the loop for (int i = 1; i < ipath.size() - 2; i++) underflowed when ipath.size() was 0, 1, or 2, since size() returns an unsigned type, producing a huge loop bound and out-of-bounds access.

The fix replaces the two fixed 500x3 stack arrays with std::vector<std::array<double, 3>> sized to ipath.size(), so the containers are heap-allocated and always match the actual input size regardless of path length. It also adds an early return, if (ipath.size() < 3) return ipath;, at the top of the function before the arrays are used, so the ipath.size() - 2 loop bound can never underflow. Every existing path[i][j] and new_path[i][j] index expression is unchanged, since std::array<double, 3> supports operator[] identically to a C array row. No other logic in the function was touched.

Verification: ran pros make from a clean worktree; it built with no new warnings and produced bin/cold.package.elf and bin/hot.package.bin (the mkdir: cannot create directory './bin': File exists / Error 1 (ignored) line is pre-existing benign noise, not a failure). I also read through the whole function to confirm there is no sizeof(path)/sizeof(new_path), no decay to a raw pointer, and no other place that assumes a C-array layout, so the container swap is safe. Reasoning on correctness: the old arrays were uninitialized and the new vectors are value-initialized, but every element that's later read is first written in the odom-to-array conversion loop, so numeric output is unchanged for any path that previously fit in 500 rows; the new size-based allocation removes the previous 500-point ceiling entirely; and the size<3 guard only changes behavior for inputs that previously triggered undefined behavior via the underflowed loop bound, turning that into a safe no-op return.

One related issue noted but left out of scope per the fix instructions: Drive::inject_points has a similar unsigned-underflow-shaped loop condition (i < input.size() - 1) a few lines above smooth_path. It wasn't touched here since it's outside the described fix.

Audit ID: H8
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 8f7b0a796d0df4cde1ff095184534dfcacb394c0 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34070887541)
- via manual download: [EZ-Template@4.0.0+8f7b0a.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000402440.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+8f7b0a.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000402440.zip;
pros c fetch EZ-Template@4.0.0+8f7b0a.zip;
pros c apply EZ-Template@4.0.0+8f7b0a;
rm EZ-Template@4.0.0+8f7b0a.zip;
```