### PR TITLE
[H9] Fix slew cap going negative and NaN slope on zero-distance slew

### DIFF
--- a/src/EZ-Template/slew.cpp
+++ b/src/EZ-Template/slew.cpp
@@ -34,6 +34,11 @@ void slew::initialize(bool enabled, double maximum_speed, double target, double 
   max_speed = maximum_speed;
 
   sign = util::sgn(target - current);
+  if (sign == 0) {
+    is_enabled = false;
+    last_output = max_speed;
+    return;
+  }
   x_intercept = current + ((constants.distance_to_travel * sign));
   y_intercept = max_speed * sign;
   slope = ((sign * constants.min_speed) - y_intercept) / (x_intercept - 0 - current);  // y2-y1 / x2-x1
@@ -51,8 +56,10 @@ double slew::iterate(double current) {
       is_enabled = false;
 
     // Return y=mx+b
-    else if (util::sgn(error) == sign)
+    else if (util::sgn(error) == sign) {
       last_output = ((slope * error) + y_intercept) * sign;
+      last_output = util::clamp(last_output, max_speed, constants.min_speed);
+    }
   } else {
     // When slew is completed, return max speed
     last_output = max_speed;


### PR DESCRIPTION
slew::iterate computed its output as ((slope * error) + y_intercept) * sign with no bounds. If a slewed motion starts with the robot moving away from the target, error can grow past distance_to_travel before its sign flips, and the uncapped line drops the output through min_speed, through zero, and negative, so drive_pid_task scales its motor command by a negative number and drives away from the target instead of toward it. Separately, slew::initialize divides by (x_intercept - current) to get slope; when target equals current, sign is 0 and x_intercept collapses to current, making that division 0/0, which produces NaN and propagates into iterate as a NaN scale factor.

This change, in src/EZ-Template/slew.cpp only, clamps last_output to [constants.min_speed, max_speed] via util::clamp(last_output, max_speed, constants.min_speed) right after it is computed in iterate, so it can never fall below min_speed or exceed max_speed. It also adds a sign == 0 guard at the top of initialize that sets is_enabled = false and last_output = max_speed and returns immediately, skipping the x_intercept/slope computation entirely so the 0/0 division never happens.

Verified with a full pros make build in a fresh worktree: all sources including slew.cpp compiled OK, and bin/cold.package.elf and bin/hot.package.bin were both produced with no new warnings. I also checked the boundary algebra by hand: at error == distance_to_travel (start of the ramp) the raw formula evaluates to exactly min_speed, and at error == 0 (end of the ramp) it evaluates to exactly max_speed, so the new clamp is a no-op during a normal forward motion and only engages when error overshoots past distance_to_travel in the wrong direction. I also confirmed util::clamp's implementation in src/EZ-Template/util.cpp treats its arguments as (input, max, min), matching how it is called here.

Audit ID: H9

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3af0c4145195e9dd3555139ba2bdc5ae372337a3 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34070890550)
- via manual download: [EZ-Template@4.0.0+3af0c4.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000403291.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+3af0c4.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000403291.zip;
pros c fetch EZ-Template@4.0.0+3af0c4.zip;
pros c apply EZ-Template@4.0.0+3af0c4;
rm EZ-Template@4.0.0+3af0c4.zip;
```