### PR TITLE
[H3] Fix invalid end() dereference and stale l_start/r_start in raw_pid_odom_pp_set

### DIFF
--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -377,15 +377,15 @@ void Drive::raw_pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
   // Set new target
   pp_movements = imovements;
 
-  raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on);
-
   // This is used for wait_until and slew
   l_start = drive_sensor_left();
   r_start = drive_sensor_right();
 
+  raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on);
+
   // Initialize slew
   int dir = current_drive_direction == REV ? -1 : 1;  // If we're going backwards, add a -1
-  double dist_to_target = util::distance_to_point(pp_movements.end()->target, odom_pose_get()) * dir;
+  double dist_to_target = util::distance_to_point(pp_movements.back().target, odom_pose_get()) * dir;
   slew_left.initialize(slew_on, max_speed, dist_to_target + l_start, l_start);
   slew_right.initialize(slew_on, max_speed, dist_to_target + r_start, r_start);
 


### PR DESCRIPTION
In Drive::raw_pid_odom_pp_set, pp_movements.end()->target dereferenced the one-past-the-last iterator returned by end(), which is undefined behavior since end() does not point to a valid element. Separately, l_start and r_start were being assigned after the call to raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on), but that function reads l_start/r_start internally to compute the leftPID/rightPID targets for the first pure pursuit segment, so those targets were being computed from the previous motion's stale sensor start values rather than this motion's actual starting position.

This change replaces pp_movements.end()->target with pp_movements.back().target, and moves the l_start = drive_sensor_left(); r_start = drive_sensor_right(); assignment to before the raw_pid_odom_ptp_set call, so the first segment's PID targets are computed from the correct starting sensor position while leaving all other behavior in the function unchanged.

Verified with a full from-scratch pros make build in a fresh worktree: it completed cleanly, producing bin/cold.package.elf and bin/hot.package.bin with no new warnings (the pre-existing benign mkdir/Error 1 (ignored) line for bin/ is unrelated and expected). Also confirmed by inspection that pp_movements.back() is equivalent to what pp_movements.end()->target was intended to reference, and that raw_pid_odom_ptp_set only reads l_start/r_start (does not itself assign them) at the point of use, so reordering is safe.

This addresses audit finding H3, deterministic-part only; the related task/setter race-condition fix for the same area is intentionally out of scope and left for a separate PR.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 97197b39b7db33216e7abbf247fc456880b3dc30 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34071387085)
- via manual download: [EZ-Template@4.0.0+97197b.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000563263.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+97197b.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000563263.zip;
pros c fetch EZ-Template@4.0.0+97197b.zip;
pros c apply EZ-Template@4.0.0+97197b;
rm EZ-Template@4.0.0+97197b.zip;
```