### PR TITLE
[H2, M6] Reset per-motion PID state and interfered flag at motion start

### DIFF
--- a/include/EZ-Template/PID.hpp
+++ b/include/EZ-Template/PID.hpp
@@ -269,6 +269,16 @@ class PID {
   void timers_reset();
 
   /**
+   * Resets the parts of the PID that must not carry over from one motion to the next.
+   * Clears the integral and primes the derivative so the first iteration of a new motion
+   * does not see a spike from the previous motion's final position.
+   *
+   * \param current
+   *        the sensor value the next compute() will be given
+   */
+  void motion_reset(double current);
+
+  /**
    * PID variables.
    */
   double output = 0.0;

--- a/src/EZ-Template/PID.cpp
+++ b/src/EZ-Template/PID.cpp
@@ -106,6 +106,14 @@ void PID::timers_reset() {
   is_mA = false;
 }
 
+void PID::motion_reset(double current) {
+  integral = 0;
+  prev_current = current;
+  cur = current;
+  derivative = 0;
+  prev_error = 0;
+}
+
 void PID::name_set(std::string p_name) {
   name = p_name;
   name_active = name == "" ? false : true;

--- a/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
@@ -104,8 +104,13 @@ void Drive::pid_drive_set(okapi::QLength p_target, int speed) {
 
 // Set drive PID raw
 void Drive::pid_drive_set(double target, int speed, bool slew_on, bool toggle_heading) {
+  interfered = false;
+
   leftPID.timers_reset();
   rightPID.timers_reset();
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
+  headingPID.motion_reset(drive_angle_get());
 
   // Print targets
   if (print_toggle) printf("Drive Started... Target Value: %.2f", target);

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -104,12 +104,18 @@ void Drive::pid_odom_set(double target, int speed) {
   pid_odom_set(target, speed, slew_on);
 }
 void Drive::pid_odom_set(double target, int speed, bool slew_on) {
+  interfered = false;
+
   drive_directions fwd_or_rev = util::sgn(target) >= 0 ? fwd : rev;
   pose target_pose = util::vector_off_point(target, {odom_x_get(), odom_y_get(), headingPID.target_get()});
   odom path = {{target_pose.x, target_pose.y}, fwd_or_rev, speed};
 
   xyPID.timers_reset();
   current_a_odomPID.timers_reset();
+  xyPID.motion_reset(new_current_fake);
+  current_a_odomPID.motion_reset(odom_theta_get());
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
 
   if (print_toggle) printf("Injected ");
   std::vector<odom> input_path = inject_points({path});
@@ -204,8 +210,14 @@ void Drive::pid_odom_injected_pp_set(std::vector<ez::odom> imovements) {
   pid_odom_injected_pp_set(imovements, slew_on);
 }
 void Drive::pid_odom_injected_pp_set(std::vector<ez::odom> imovements, bool slew_on) {
+  interfered = false;
+
   xyPID.timers_reset();
   current_a_odomPID.timers_reset();
+  xyPID.motion_reset(new_current_fake);
+  current_a_odomPID.motion_reset(odom_theta_get());
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
 
   if (print_toggle) printf("Injected ");
   std::vector<odom> input_path = inject_points(set_odoms_direction(imovements));
@@ -234,8 +246,14 @@ void Drive::pid_odom_smooth_pp_set(std::vector<odom> imovements) {
   pid_odom_smooth_pp_set(imovements, slew_on);
 }
 void Drive::pid_odom_smooth_pp_set(std::vector<odom> imovements, bool slew_on) {
+  interfered = false;
+
   xyPID.timers_reset();
   current_a_odomPID.timers_reset();
+  xyPID.motion_reset(new_current_fake);
+  current_a_odomPID.motion_reset(odom_theta_get());
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
 
   if (print_toggle) printf("Smooth Injected ");
   std::vector<odom> input_path = smooth_path(inject_points(set_odoms_direction(imovements)), odom_smooth_weight_smooth, odom_smooth_weight_data, odom_smooth_tolerance);
@@ -281,8 +299,14 @@ void Drive::pid_odom_boomerang_set(united_odom p_imovement, bool slew_on) {
 // External base pure pursuit
 /////
 void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
+  interfered = false;
+
   xyPID.timers_reset();
   current_a_odomPID.timers_reset();
+  xyPID.motion_reset(new_current_fake);
+  current_a_odomPID.motion_reset(odom_theta_get());
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
 
   std::vector<odom> input = set_odoms_direction(imovements);
   input.insert(input.begin(), {{{odom_x_get(), odom_y_get(), ANGLE_NOT_SET}, imovements[0].drive_direction, imovements[0].max_xy_speed}});
@@ -332,6 +356,8 @@ void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
 // External base ptp
 /////
 void Drive::pid_odom_ptp_set(odom imovement, bool slew_on) {
+  interfered = false;
+
   imovement = set_odom_direction(imovement);
 
   odom_second_to_last = odom_pose_get();
@@ -340,6 +366,10 @@ void Drive::pid_odom_ptp_set(odom imovement, bool slew_on) {
 
   xyPID.timers_reset();
   current_a_odomPID.timers_reset();
+  xyPID.motion_reset(new_current_fake);
+  current_a_odomPID.motion_reset(odom_theta_get());
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
 
   // This is used for wait_until and slew
   l_start = drive_sensor_left();

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -280,7 +280,12 @@ void Drive::pid_swing_relative_set(e_swing type, okapi::QAngle p_target, int spe
 // Swing set base
 /////
 void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
+  interfered = false;
+
   swingPID.timers_reset();
+  swingPID.motion_reset(drive_angle_get());
+  leftPID.motion_reset(drive_sensor_left());
+  rightPID.motion_reset(drive_sensor_right());
 
   // Set turn behavior
   current_angle_behavior = behavior;

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -117,7 +117,10 @@ void Drive::pid_turn_relative_set(okapi::QAngle p_target, int speed, e_angle_beh
 // Turn to angle base
 /////
 void Drive::pid_turn_set(double target, int speed, e_angle_behavior behavior, bool slew_on) {
+  interfered = false;
+
   turnPID.timers_reset();
+  turnPID.motion_reset(drive_angle_get());
 
   // Set turn behavior
   current_angle_behavior = behavior;


### PR DESCRIPTION
Two related bugs in the drive PID setters. H2: PID objects carried integral, derivative, and prev_error/prev_current state over from one motion to the next, so the first compute() of a new motion could see a derivative or integral spike computed against the previous motion's final position rather than a fresh start. M6: Drive::interfered is set to true in seven places in exit_conditions.cpp but nothing ever set it back to false, so once any single motion was interfered every subsequent motion's pid_wait_* checks read interfered as true forever.

For H2, added ez::PID::motion_reset(current) (declared in include/EZ-Template/PID.hpp, defined in src/EZ-Template/PID.cpp), which zeroes integral and derivative, sets prev_error to 0, and primes prev_current/cur to the given current sensor value. It intentionally leaves target, constants, exit, and the timer members alone since those are handled separately by timers_reset(). Calls to motion_reset were added at the top of the base pid_drive_set, the base pid_turn_set, the base pid_swing_set, and all five pid_odom_* public entry points (pid_odom_set, pid_odom_injected_pp_set, pid_odom_smooth_pp_set, pid_odom_pp_set, pid_odom_ptp_set), right next to the existing timers_reset() calls already there. raw_pid_odom_ptp_set, which runs per-waypoint from the pure-pursuit task, was deliberately left untouched.

For M6, interfered = false was added at the top of those same eight functions.

One note: the odom entry points call xyPID.motion_reset(new_current_fake) using the existing new_current_fake member as specified, even though that member is itself never reset elsewhere in the library. That's a separate, pre-existing oddity outside the scope of this fix and was left as-is.

Verified with a clean from-scratch pros make build (all files compiled OK, bin/cold.package.elf and bin/hot.package.bin produced with no new warnings), plus manual reasoning through each touched call site to confirm timers_reset()/motion_reset()/interfered=false placement matches the existing pattern in each function and that no other members (target, constants, exit, timer counters) are touched.

Audit IDs: H2, M6
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 7c2c6b8415ee960fb97b4706e983d0bad20d5134 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34071558683)
- via manual download: [EZ-Template@4.0.0+7c2c6b.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000621365.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+7c2c6b.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000621365.zip;
pros c fetch EZ-Template@4.0.0+7c2c6b.zip;
pros c apply EZ-Template@4.0.0+7c2c6b;
rm EZ-Template@4.0.0+7c2c6b.zip;
```