### PR TITLE
[H4, M3] Fix tracking angle sign and add sensor priming on odom (re)start

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3647,6 +3647,7 @@ class Drive {
   std::pair<float, float> decide_vert_sensor(ez::tracking_wheel* tracker, bool is_tracker_enabled, float ime = 0.0, float ime_track = 0.0);
   pose solve_xy_vert(float p_track_width, float current_t, float delta_vert, float delta_t);
   pose solve_xy_horiz(float p_track_width, float current_t, float delta_horiz, float delta_t);
+  void tracking_prime();
   bool was_last_pp_mode_boomerang = false;
   bool global_forward_drive_slew_enabled = false;
   bool global_backward_drive_slew_enabled = false;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -352,12 +352,6 @@ void Drive::drive_sensor_reset() {
   left_activebrakePID.target_set(0.0);
   right_activebrakePID.target_set(0.0);
 
-  // Reset odom stuff
-  h_last = 0.0;
-  l_last = 0.0;
-  r_last = 0.0;
-  t_last = 0.0;
-
   // Reset sensors
   left_motors.front().tare_position();
   right_motors.front().tare_position();
@@ -368,12 +362,13 @@ void Drive::drive_sensor_reset() {
   if (is_tracker == DRIVE_ADI_ENCODER) {
     left_tracker.reset();
     right_tracker.reset();
-    return;
   } else if (is_tracker == DRIVE_ROTATION) {
     left_rotation.reset_position();
     right_rotation.reset_position();
-    return;
   }
+
+  // Reset odom stuff to the freshly-zeroed sensor values
+  tracking_prime();
 }
 
 int Drive::drive_sensor_right_raw() {
@@ -421,7 +416,7 @@ void Drive::drive_imu_reset(double new_heading) {
     good_imus[i]->set_rotation(new_heading / scale);
   }
   angle_rad = util::to_rad(new_heading);
-  t_last = angle_rad;
+  t_last = -angle_rad;
 }
 double Drive::get_this_imu(pros::Imu* imu) { return imu->get_rotation() * imu_scale_map[imu->get_port()]; }
 

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -131,6 +131,29 @@ ez::pose Drive::solve_xy_horiz(float p_track_width, float current_t, float delta
   return output;
 }
 
+// Primes the "last" sensor values to the current readings, without touching
+// any of the accumulated pose data. Used whenever tracking is (re)started so
+// the next tracking pass computes a real delta instead of jumping by however
+// much the sensors accumulated while tracking was paused/disabled.
+void Drive::tracking_prime() {
+  // Decide on using a horiz tracker vs not
+  ez::tracking_wheel* h_sensor = odom_tracker_back != nullptr ? odom_tracker_back : odom_tracker_front;
+  bool h_tracker_enabled = h_sensor == odom_tracker_back ? odom_tracker_back_enabled : odom_tracker_front_enabled;
+  std::pair<float, float> h_cur_and_track = decide_vert_sensor(h_sensor, h_tracker_enabled);
+  h_last = h_cur_and_track.first;
+
+  // Decide on left ime vs left tracker
+  std::pair<float, float> l_cur_and_track = decide_vert_sensor(odom_tracker_left, odom_tracker_left_enabled, drive_sensor_left(), odom_ime_track_width_left);
+  l_last = l_cur_and_track.first;
+
+  // Decide on right ime vs right tracker
+  std::pair<float, float> r_cur_and_track = decide_vert_sensor(odom_tracker_right, odom_tracker_right_enabled, drive_sensor_right(), odom_ime_track_width_right);
+  r_last = r_cur_and_track.first;
+
+  // Angle, matching the sign convention used in tracking_wheels_tracking()
+  t_last = -ez::util::to_rad(drive_angle_get());
+}
+
 // Tracking based on https://wiki.purduesigbots.com/software/odometry
 void Drive::tracking_wheels_tracking() {
   // Decide on using a horiz tracker vs not
@@ -219,12 +242,9 @@ void Drive::tracking_wheels_tracking() {
 
 void Drive::ez_tracking_task() {
   // Don't let this function run if odom is disabled
-  // and make sure all the "lasts" are 0
+  // and prime the "lasts" to the current sensor values
   if (!imu_calibration_complete || !odometry_enabled) {
-    h_last = 0.0;
-    t_last = 0.0;
-    l_last = 0.0;
-    r_last = 0.0;
+    tracking_prime();
     return;
   }
 


### PR DESCRIPTION
Drive::drive_imu_reset() wrote t_last as positive angle_rad while Drive::tracking_wheels_tracking() integrates heading using the -to_rad(drive_angle_get()) convention everywhere else, so calling drive_imu_reset() injected a fake heading delta of roughly -pi radians into the next tracking pass with zero actual wheel motion, which gets multiplied through the tracker offset math and moves the pose by roughly double the intended amount. Separately, Drive::drive_sensor_reset() and the disabled branch of Drive::ez_tracking_task() (which runs every loop while odom is disabled or the IMU isn't calibrated yet) both zeroed h_last/l_last/r_last/t_last unconditionally instead of priming them to the robot's actual current sensor readings, so the first tracking pass after odom/IMU comes back online integrated the entire accumulated sensor value as if it happened in a single tick, producing a large spurious pose jump.

This change adds a new private helper, Drive::tracking_prime(), defined in src/EZ-Template/drive/tracking.cpp, which primes h_last/l_last/r_last/t_last to the current sensor readings using the exact same sensor-selection logic tracking_wheels_tracking() already uses (decide_vert_sensor with the same back/front and left/right tracker fallbacks), with t_last set via the same -to_rad(drive_angle_get()) sign convention. It is declared in include/EZ-Template/drive/drive.hpp next to the other private tracking helpers (decide_vert_sensor, solve_xy_vert, solve_xy_horiz); tracking_wheels_tracking() itself is actually public in the current header (there is only one access-specifier pair in the class, public at the top and private starting later), so tracking_prime() was placed by the "private member function" intent rather than literally beside tracking_wheels_tracking()'s declaration. drive_sensor_reset() now calls tracking_prime() once, after the sensors are tared/reset and after the tracker-type branch, instead of zeroing the four fields up front, so it primes from freshly-zeroed sensor values. That required removing two return statements that were the last statements inside the DRIVE_ADI_ENCODER and DRIVE_ROTATION branches of that if/else-if chain; nothing followed them before this change, so removing them is safe, and it lets every tracker configuration (ADI encoder, rotation sensor, or neither) reach the new tracking_prime() call. The disabled branch of ez_tracking_task() now calls tracking_prime() instead of directly zeroing the four fields, keeping its existing return right after. drive_imu_reset() now sets t_last to -angle_rad instead of +angle_rad to match the sign convention.

Verified with a full pros make build from a clean worktree, which completed with no errors or warnings introduced by this change (bin/cold.package.elf and bin/hot.package.bin both built). No behavior could be exercised through unit tests since this is a PROS/VEX hardware library without a host-side test harness; the fix was verified by re-reading tracking_wheels_tracking(), drive_sensor_reset(), drive_imu_reset(), and ez_tracking_task() line by line and confirming every "last" field write is now either a real primed sensor value or consistent with the existing -to_rad(drive_angle_get()) sign convention, and by grepping the whole tree for h_last/l_last/r_last/t_last to confirm there are no other writers left using the old zero-or-wrong-sign behavior.

One thing worth flagging separately: tracking_prime() calls drive_angle_get() even while imu_calibration_complete is false. pros::Imu::get_rotation() returns PROS_ERR_F (INFINITY) with errno EAGAIN while an IMU is still calibrating, so t_last could be primed to an infinite value on ticks that land during active calibration. This was already possible in principle before this change in the "enabled" path, but the old disabled-branch code sidestepped it entirely by hardcoding t_last to 0.0. In practice this only matters for whichever tracking-task tick happens to land in the narrow window between the IMU finishing calibration and imu_calibration_complete flipping true, and only until the next call to drive_sensor_reset() or drive_imu_reset() re-primes it, but it's a narrow edge case Jess may want to double check rather than something addressed here, since the task scope is only the sign/priming fix.

Hardware check for Jess: with a single vertical tracker at 3.5 in and a horizontal tracker at 2 in, odom_xyt_set(0_in, 0_in, 90_deg) currently moves the pose to about (-4, -7) while the robot is stationary; after this change it should stay at (0, 0). I can't run this on hardware myself, so please verify it on a real robot before merging.

Audit IDs: H4, M3

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: ee10529b0c93d0145efa856e73224412d0b5b4c3 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34071683939)
- via manual download: [EZ-Template@4.0.0+ee1052.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000657791.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+ee1052.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10000657791.zip;
pros c fetch EZ-Template@4.0.0+ee1052.zip;
pros c apply EZ-Template@4.0.0+ee1052;
rm EZ-Template@4.0.0+ee1052.zip;
```