### PR TITLE
[H3] Add drive_mutex to fix task/setter race

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -9,6 +9,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <deque>
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <stack>
 #include <tuple>
 
@@ -21,6 +22,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include "okapi/api/units/QTime.hpp"
 #include "pros/motor_group.hpp"
 #include "pros/motors.h"
+#include "pros/rtos.hpp"
 
 //using namespace ez;
 
@@ -3574,6 +3576,12 @@ class Drive {
   void odom_tracking_set(std::function<void(void)> tracking_task);
 
  private:
+  /**
+   * Guards state shared between the ez_auto task and the public setters.
+   * Recursive so nested public calls and user callbacks that call setters are safe.
+   */
+  pros::RecursiveMutex drive_mutex;
+
   std::function<void(void)> tracking;
   void opcontrol_drive_activebrake_targets_set();
   double odom_smooth_weight_smooth = 0.0;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -348,6 +348,8 @@ int Drive::drive_current_limit_get() {
 
 // Motor telemetry
 void Drive::drive_sensor_reset() {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   // Update active brake constants
   left_activebrakePID.target_set(0.0);
   right_activebrakePID.target_set(0.0);
@@ -408,6 +410,8 @@ double Drive::drive_mA_left() { return left_motors.front().get_current_draw(); }
 bool Drive::drive_current_left_over() { return left_motors.front().is_over_current(); }
 
 void Drive::drive_imu_reset(double new_heading) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   for (int i = 0; i < good_imus.size(); i++) {
     // Reads go through get_this_imu(), which multiplies by the scaler, so the
     // value written here has to be divided by it to read back as new_heading
@@ -426,10 +430,15 @@ double Drive::drive_imu_accel_get() {
   return std::hypot(accel.x, accel.y);
 }
 
-void Drive::drive_imu_scaler_set(double scaler) { imu_scale_map[imu->get_port()] = scaler; }
+void Drive::drive_imu_scaler_set(double scaler) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+  imu_scale_map[imu->get_port()] = scaler;
+}
 double Drive::drive_imu_scaler_get() { return imu_scale_map[imu->get_port()]; }
 
 void Drive::drive_imus_scalers_set(std::vector<double> scales) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   for (int i = 0; i < std::min(good_imus.size(), scales.size()); i++) {
     imu_scale_map[good_imus[i]->get_port()] = scales[i];
   }
@@ -512,7 +521,6 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
     if (iter >= 2000) {
       if (successful) {
         printf("IMU is done calibrating (took %d ms)\n", iter);
-        imu_calibration_complete = true;
         imu_calibrate_took_too_long = iter > 2000 ? true : false;
         break;
       }
@@ -537,18 +545,22 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
   }
 
   // Run through all of the IMUs and remove any IMUs that didn't calibrate successfully
-  for (int i = 0; i < good_imus.size(); i++) {
-    int port = good_imus[i]->get_port();
+  {
+    std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-    if (!imus_done[port]) {
-      good_imus.erase(good_imus.begin() + i);
-      if (i == 0 && !good_imus.empty())
-        imu = good_imus.front();
+    for (int i = 0; i < good_imus.size(); i++) {
+      int port = good_imus[i]->get_port();
+
+      if (!imus_done[port]) {
+        good_imus.erase(good_imus.begin() + i);
+        if (i == 0 && !good_imus.empty())
+          imu = good_imus.front();
+      }
     }
-  }
 
-  if (one_calibrated && !good_imus.empty())
-    imu_calibration_complete = true;
+    if (one_calibrated && !good_imus.empty())
+      imu_calibration_complete = true;
+  }
 
   printf("one cali-%i\n", one_calibrated);
 
@@ -584,6 +596,8 @@ void Drive::initialize(bool run_loading_animation) {
 }
 
 void Drive::odom_tracker_left_set(tracking_wheel* input) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   if (input == nullptr) return;
 
   odom_tracker_left = input;
@@ -598,6 +612,8 @@ void Drive::odom_tracker_left_set(tracking_wheel* input) {
     is_tracker = ODOM_TRACKER;
 }
 void Drive::odom_tracker_right_set(tracking_wheel* input) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   if (input == nullptr) return;
 
   odom_tracker_right = input;
@@ -609,12 +625,16 @@ void Drive::odom_tracker_right_set(tracking_wheel* input) {
     is_tracker = ODOM_TRACKER;
 }
 void Drive::odom_tracker_front_set(tracking_wheel* input) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   if (input == nullptr) return;
 
   odom_tracker_front = input;
   odom_tracker_front_enabled = true;
 }
 void Drive::odom_tracker_back_set(tracking_wheel* input) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   if (input == nullptr) return;
 
   odom_tracker_back = input;

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -482,54 +482,58 @@ double Drive::pid_swing_chain_backward_constant_get() { return swing_backward_mo
 
 // Pid wait that hold momentum into the next motion
 void Drive::pid_wait_quick_chain() {
-  // If driving, add drive_motion_chain_scale to target
-  if (mode == DRIVE) {
-    double chain_scale = motion_chain_backward ? drive_backward_motion_chain_scale : drive_forward_motion_chain_scale;
-    used_motion_chain_scale = chain_scale * util::sgn(chain_target_start);
-    leftPID.target_set(leftPID.target_get() + used_motion_chain_scale);
-    rightPID.target_set(rightPID.target_get() + used_motion_chain_scale);
-  }
+  {
+    std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  // If turning, add turn_motion_chain_scale to target
-  else if (mode == TURN) {
-    used_motion_chain_scale = turn_motion_chain_scale * util::sgn(chain_target_start - chain_sensor_start);
-    turnPID.target_set(turnPID.target_get() + used_motion_chain_scale);
-  }
+    // If driving, add drive_motion_chain_scale to target
+    if (mode == DRIVE) {
+      double chain_scale = motion_chain_backward ? drive_backward_motion_chain_scale : drive_forward_motion_chain_scale;
+      used_motion_chain_scale = chain_scale * util::sgn(chain_target_start);
+      leftPID.target_set(leftPID.target_get() + used_motion_chain_scale);
+      rightPID.target_set(rightPID.target_get() + used_motion_chain_scale);
+    }
 
-  // If swinging, add swing_motion_chain_scale to target
-  else if (mode == SWING) {
-    double chain_scale = motion_chain_backward ? swing_backward_motion_chain_scale : swing_forward_motion_chain_scale;
-    used_motion_chain_scale = chain_scale * util::sgn(chain_target_start - chain_sensor_start);
-    swingPID.target_set(swingPID.target_get() + used_motion_chain_scale);
-  }
+    // If turning, add turn_motion_chain_scale to target
+    else if (mode == TURN) {
+      used_motion_chain_scale = turn_motion_chain_scale * util::sgn(chain_target_start - chain_sensor_start);
+      turnPID.target_set(turnPID.target_get() + used_motion_chain_scale);
+    }
 
-  // If odometrying, add drive_motion_chain_scale to the final target point
-  // It'll be at the angle between the second to last point and the last point
-  else if (mode == POINT_TO_POINT || mode == PURE_PURSUIT) {
-    double chain_scale = current_drive_direction == REV ? drive_backward_motion_chain_scale : drive_forward_motion_chain_scale;
-    used_motion_chain_scale = chain_scale;
+    // If swinging, add swing_motion_chain_scale to target
+    else if (mode == SWING) {
+      double chain_scale = motion_chain_backward ? swing_backward_motion_chain_scale : swing_forward_motion_chain_scale;
+      used_motion_chain_scale = chain_scale * util::sgn(chain_target_start - chain_sensor_start);
+      swingPID.target_set(swingPID.target_get() + used_motion_chain_scale);
+    }
 
-    // Figure out what angle to use.
-    // this will either by the angle between second to last point and last point,
-    // or it'll be the boomerang end angle
-    double angle = util::absolute_angle_to_point(odom_target_start, odom_second_to_last);
-    if (odom_target_start.theta != ANGLE_NOT_SET) angle = odom_target_start.theta;
+    // If odometrying, add drive_motion_chain_scale to the final target point
+    // It'll be at the angle between the second to last point and the last point
+    else if (mode == POINT_TO_POINT || mode == PURE_PURSUIT) {
+      double chain_scale = current_drive_direction == REV ? drive_backward_motion_chain_scale : drive_forward_motion_chain_scale;
+      used_motion_chain_scale = chain_scale;
 
-    // Create new point
-    pose target = util::vector_off_point(used_motion_chain_scale, {odom_target_start.x, odom_target_start.y, angle});
-    target.theta = odom_target_start.theta;
+      // Figure out what angle to use.
+      // this will either by the angle between second to last point and last point,
+      // or it'll be the boomerang end angle
+      double angle = util::absolute_angle_to_point(odom_target_start, odom_second_to_last);
+      if (odom_target_start.theta != ANGLE_NOT_SET) angle = odom_target_start.theta;
 
-    // Replace target in ptp, add new final point if pp
-    if (mode == POINT_TO_POINT)
-      odom_target = target;
-    else
-      pp_movements.push_back({target,
-                              pp_movements[pp_movements.size() - 1].drive_direction,
-                              pp_movements[pp_movements.size() - 1].max_xy_speed});
+      // Create new point
+      pose target = util::vector_off_point(used_motion_chain_scale, {odom_target_start.x, odom_target_start.y, angle});
+      target.theta = odom_target_start.theta;
 
-  } else {
-    printf("Not in a supported drive mode!\n");
-    return;
+      // Replace target in ptp, add new final point if pp
+      if (mode == POINT_TO_POINT)
+        odom_target = target;
+      else
+        pp_movements.push_back({target,
+                                pp_movements[pp_movements.size() - 1].drive_direction,
+                                pp_movements[pp_movements.size() - 1].max_xy_speed});
+
+    } else {
+      printf("Not in a supported drive mode!\n");
+      return;
+    }
   }
 
   // Exit at the real target

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -12,37 +12,41 @@ using namespace ez;
 
 void Drive::ez_auto_task() {
   while (true) {
-    // Check IMUs for redundancy
-    check_imu_task();
+    {
+      std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-    // Run odom
-    ez_tracking_task();
+      // Check IMUs for redundancy
+      check_imu_task();
 
-    // Autonomous PID
-    switch (drive_mode_get()) {
-      case DRIVE:
-        drive_pid_task();
-        break;
-      case TURN ... TURN_TO_POINT:
-        turn_pid_task();
-        break;
-      case SWING:
-        swing_pid_task();
-        break;
-      case POINT_TO_POINT:
-        ptp_task();
-        break;
-      case PURE_PURSUIT:
-        pp_task();
-        break;
-      case DISABLE:
-        break;
-      default:
-        break;
+      // Run odom
+      ez_tracking_task();
+
+      // Autonomous PID
+      switch (drive_mode_get()) {
+        case DRIVE:
+          drive_pid_task();
+          break;
+        case TURN ... TURN_TO_POINT:
+          turn_pid_task();
+          break;
+        case SWING:
+          swing_pid_task();
+          break;
+        case POINT_TO_POINT:
+          ptp_task();
+          break;
+        case PURE_PURSUIT:
+          pp_task();
+          break;
+        case DISABLE:
+          break;
+        default:
+          break;
+      }
+
+      // This is used to reset sensors for active braking
+      util::AUTON_RAN = drive_mode_get() != DISABLE ? true : false;
     }
-
-    // This is used to reset sensors for active braking
-    util::AUTON_RAN = drive_mode_get() != DISABLE ? true : false;
 
     pros::delay(ez::util::DELAY_TIME);
   }

--- a/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_drive_pid.cpp
@@ -51,6 +51,8 @@ void Drive::pid_heading_constants_set(double p, double i, double d, double p_sta
   headingPID.constants_set(p, i, d, p_start_i);
 }
 void Drive::drive_angle_set(double angle) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   headingPID.target_set(angle);
   drive_imu_reset(angle);
   central_pose.theta = angle;
@@ -104,6 +106,8 @@ void Drive::pid_drive_set(okapi::QLength p_target, int speed) {
 
 // Set drive PID raw
 void Drive::pid_drive_set(double target, int speed, bool slew_on, bool toggle_heading) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   interfered = false;
 
   leftPID.timers_reset();

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -356,6 +356,8 @@ void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
 // External base ptp
 /////
 void Drive::pid_odom_ptp_set(odom imovement, bool slew_on) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   interfered = false;
 
   imovement = set_odom_direction(imovement);
@@ -394,6 +396,8 @@ void Drive::pid_odom_ptp_set(odom imovement, bool slew_on) {
 // Base pure pursuit
 /////
 void Drive::raw_pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   odom_second_to_last = imovements[imovements.size() - 2].target;
   odom_target_start = imovements[imovements.size() - 1].target;
   odom_start = odom_pose_get();

--- a/src/EZ-Template/drive/set_pid/set_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_pid.cpp
@@ -12,6 +12,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 namespace ez {
 // Updates max speed
 void Drive::pid_speed_max_set(int speed) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   max_speed = std::fabs(util::clamp(speed, 127, -127));
   slew_left.speed_max_set(max_speed);
   slew_right.speed_max_set(max_speed);
@@ -50,6 +52,8 @@ void Drive::pid_angle_behavior_set(ez::e_angle_behavior behavior) {
 }
 
 void Drive::pid_targets_reset() {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   headingPID.target_set(0);
   leftPID.target_set(0);
   rightPID.target_set(0);

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -280,6 +280,8 @@ void Drive::pid_swing_relative_set(e_swing type, okapi::QAngle p_target, int spe
 // Swing set base
 /////
 void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   interfered = false;
 
   swingPID.timers_reset();

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -117,6 +117,8 @@ void Drive::pid_turn_relative_set(okapi::QAngle p_target, int speed, e_angle_beh
 // Turn to angle base
 /////
 void Drive::pid_turn_set(double target, int speed, e_angle_behavior behavior, bool slew_on) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   interfered = false;
 
   turnPID.timers_reset();
@@ -179,6 +181,8 @@ void Drive::pid_turn_set(united_pose p_itarget, drive_directions dir, int speed,
 // Turn to point base
 /////
 void Drive::pid_turn_set(pose itarget, drive_directions dir, int speed, e_angle_behavior behavior, bool slew_on) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   itarget = flip_pose(itarget);
   odom_imu_start = drive_angle_get();
 

--- a/src/EZ-Template/drive/tracking.cpp
+++ b/src/EZ-Template/drive/tracking.cpp
@@ -13,6 +13,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 namespace ez {
 // Sets and gets
 void Drive::odom_x_set(double x) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   odom_current.x = x;
   l_pose.x = x;
   r_pose.x = x;
@@ -21,6 +23,8 @@ void Drive::odom_x_set(double x) {
 }
 void Drive::odom_x_set(okapi::QLength p_x) { odom_x_set(p_x.convert(okapi::inch)); }
 void Drive::odom_y_set(double y) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   odom_current.y = y;
   l_pose.y = y;
   r_pose.y = y;
@@ -31,6 +35,8 @@ void Drive::odom_y_set(okapi::QLength p_y) { odom_y_set(p_y.convert(okapi::inch)
 void Drive::odom_theta_set(double a) { drive_angle_set(a); }
 void Drive::odom_theta_set(okapi::QAngle p_a) { odom_theta_set(p_a.convert(okapi::degree)); }
 void Drive::drive_width_set(double input) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+
   global_track_width = fabs(input);
   if (input != 0.0) {
     odom_ime_track_width_left = -(global_track_width / 2.0);
@@ -59,7 +65,10 @@ void Drive::odom_pose_set(pose itarget) {
 }
 void Drive::odom_pose_set(united_pose itarget) { odom_pose_set(util::united_pose_to_pose(itarget)); }
 void Drive::odom_reset() { odom_pose_set({0.0, 0.0, 0.0}); }
-void Drive::odom_enable(bool input) { odometry_enabled = input; }
+void Drive::odom_enable(bool input) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+  odometry_enabled = input;
+}
 bool Drive::odom_enabled() { return odometry_enabled; }
 
 double Drive::odom_x_get() { return odom_current.x; }
@@ -70,7 +79,10 @@ double Drive::drive_width_get() { return global_track_width; }
 
 // Set tracking task
 // void Drive::odom_tracking_set(void (*tracking_task)()) { tracking = tracking_task; }
-void Drive::odom_tracking_set(std::function<void(void)> tracking_task) { tracking = tracking_task; }
+void Drive::odom_tracking_set(std::function<void(void)> tracking_task) {
+  std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+  tracking = tracking_task;
+}
 
 std::pair<float, float> Drive::decide_vert_sensor(ez::tracking_wheel* tracker, bool is_tracker_enabled, float ime, float ime_track) {
   float current = ime;


### PR DESCRIPTION
## What was wrong

`ez::Drive` has no lock, but three tasks touch its state concurrently. `ez_auto_task()` (`pid_tasks.cpp`) runs every 10ms and reads `pp_movements`, `pp_index`, `odom_target`, `point_to_face`, the PID objects, the slew objects, `good_imus`, and the tracking state. The user's auton task calls the public `pid_*_set` functions, which rewrite all of that while the task is mid-pass, because `mode` is never set back to `DISABLE` between motions. The worst case is `raw_pid_odom_pp_set` doing `pp_movements.clear(); pp_index = 0; pp_movements = imovements;` while `pp_task` is indexing `pp_movements[pp_index]`, and `pid_wait_quick_chain` doing a `push_back` on the same vector concurrently. Other races: `odom_x_set`/`odom_y_set` and tracking's `central_pose` writes hit the same doubles the tracking task updates every pass (a lost update at the start of an auton), and `check_imu_task` erasing from `good_imus` while `drive_imu_reset`/`drive_imu_calibrate` iterate the same deque.

## What the change does

Adds one `pros::RecursiveMutex drive_mutex` to `Drive` (private, in `drive.hpp`). It's recursive so nested public calls (e.g. `pid_turn_set(pose, ...)` calling `pid_turn_set(double, ...)`, every setter calling `pid_speed_max_set`) and a user tracking callback that calls a setter can't deadlock.

**Locking rules (for review):** `ez_auto_task()`'s `while(true)` body is wrapped in a lock scope covering everything except the trailing `pros::delay`, so the delay runs unlocked and setters aren't starved. The base overload of each public setter takes the lock as its first statement: `pid_drive_set` (4-arg base), both `pid_turn_set` bases (angle and turn-to-point), `drive_angle_set`, `pid_swing_set` (6-arg base), `raw_pid_odom_pp_set`, `pid_odom_ptp_set` (2-arg base), `pid_speed_max_set`, `pid_targets_reset`, `drive_sensor_reset`, `drive_imu_reset`, `drive_imu_scaler_set`, `drive_imus_scalers_set`, all four `odom_tracker_*_set` functions, `odom_x_set`, `odom_y_set`, `odom_enable`, `odom_tracking_set`, and `drive_width_set`. `raw_pid_odom_pp_set` is locked directly instead of in its four callers so the expensive `inject_points()`/`smooth_path()` work stays outside the lock. `pid_wait_quick_chain` only locks the `if`/`else if` chain that mutates PID targets and `pp_movements`; the trailing `pid_wait_quick()` call (which loops with delays) runs unlocked. `drive_imu_calibrate` only locks the final `good_imus.erase()` cleanup loop — the rest of the function sleeps in a loop and must not hold the lock; the `imu_calibration_complete = true` that used to sit inside the calibration wait loop was removed so the flag only flips after the now-locked cleanup loop runs, closing the window where `check_imu_task` (which returns early while the flag is false) could erase from `good_imus` at the same time. Everything else — wait functions (`pid_wait*`, `wait_until_*`), `drive_set`/`user_input.cpp`, getters, constants setters, and the PID tuner — is intentionally left unlocked: they either loop with `pros::delay` (which must never run while holding this lock) or are single-word/small-struct writes where a torn read costs one PID iteration, not a crash. No behavior changes outside the locking itself — the same statements run in the same order.

## How this was verified

1. `pros make` builds clean in a worktree off `origin/dev` with just this change.
2. Read back every function that takes `drive_mutex` and confirmed none of them call `pros::delay`, `pros::Task::delay_until`, or block on the SD card/controller/screen while holding it.
3. Grepped `src/EZ-Template/drive/` and `include/EZ-Template/drive/drive.hpp` for `pros::delay`/`Task::delay_until`; the only delay inside `drive_imu_calibrate` is in its calibration wait loop, which runs before the lock is taken. The one thing that can't be grep-verified: a user-supplied `odom_tracking_set` callback runs inside `ez_auto_task`'s locked section (via `ez_tracking_task`), so **a custom tracking function must not sleep** — this is a documented constraint of the change, not something this PR can enforce.
4. Hardware soak (not run here, checklist for whoever tests this on a robot): an auton chaining 8+ odom motions with `pid_wait_quick_chain` between them, looped for 30 minutes, should finish every loop with pose within normal drift of where it started and the brain should never reboot. Before this change that loop had a small chance per motion of a random wild move or a data abort from the `pp_movements` race.

Audit ID: **H3, race half** (the other half of H3 — the `pp_movements.end()`/stale `l_start`/`r_start` bug — was already fixed in #354).

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 162b30face6629fc745413eb7f2d303c7b951b72 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34076708879)
- via manual download: [EZ-Template@4.0.0+162b30.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002292100.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+162b30.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002292100.zip;
pros c fetch EZ-Template@4.0.0+162b30.zip;
pros c apply EZ-Template@4.0.0+162b30;
rm EZ-Template@4.0.0+162b30.zip;
```