### PR TITLE
Rework IMU watchdog to survive a stationary robot

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3615,6 +3615,16 @@ class Drive {
   double turn_left(double target, double current, bool print = false);
   double turn_right(double target, double current, bool print = false);
   bool imu_calibration_complete = false;
+
+  // IMU watchdog state: every IMU ever constructed (never shrinks), and
+  // per-port health tracking used by check_imu_task() to eject/re-add IMUs.
+  std::deque<pros::Imu*> all_imus;
+  std::map<int, int> imu_stuck_passes;
+  std::map<int, int> imu_healthy_passes;
+  double last_good_angle = 0.0;
+  double watchdog_l_last = 0.0, watchdog_r_last = 0.0;
+  bool imu_only_imu_warning_shown = false;
+
   bool is_swing_slew_enabled(e_swing type, double target, double current);
   bool slew_reenables_when_max_speed_changes = true;
   int slew_min_when_it_enabled = 0;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -4,6 +4,7 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <algorithm>
 #include <cmath>
 #include <list>
 
@@ -38,6 +39,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   }
 
   good_imus.push_back(imu);
+  all_imus.push_back(imu);
   drive_imu_scaler_set(1);
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
@@ -74,10 +76,12 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   // Set all IMUs
   std::vector<double> imu_scale_values = {};
   good_imus.push_back(imu);
+  all_imus.push_back(imu);
   imu_scale_values.push_back(1);
   for (int i = 1; i < imu_ports.size(); i++) {
     pros::Imu* temp = new pros::Imu(imu_ports[i]);
     good_imus.push_back(temp);
+    all_imus.push_back(temp);
     imu_scale_values.push_back(1);
   }
   drive_imus_scalers_set(imu_scale_values);
@@ -116,6 +120,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   }
 
   good_imus.push_back(imu);
+  all_imus.push_back(imu);
   drive_imu_scaler_set(1);
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
@@ -151,6 +156,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   }
 
   good_imus.push_back(imu);
+  all_imus.push_back(imu);
   drive_imu_scaler_set(1);
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
@@ -188,6 +194,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   }
 
   good_imus.push_back(imu);
+  all_imus.push_back(imu);
   drive_imu_scaler_set(1);
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
@@ -199,19 +206,17 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
 }
 
 Drive::~Drive() {
-  delete imu;
-  good_imus.pop_front();
-
-  while (!good_imus.empty()) {
-    delete good_imus.front();
-    good_imus.pop_front();
+  for (pros::Imu* n : all_imus) {
+    delete n;
   }
+  good_imus.clear();
+  all_imus.clear();
 }
 
 // set defaults
 void Drive::drive_defaults_set() {
   for (int i = 0; i < good_imus.size(); i++) {
-    imu->set_data_rate(5);
+    good_imus[i]->set_data_rate(5);
   }
 
   std::cout << std::fixed;
@@ -281,10 +286,7 @@ void Drive::drive_defaults_set() {
 }
 
 double Drive::drive_angle_get() {
-  /*if there is a good imu*/
-  if (imu != nullptr) return drive_imu_get();
-
-  return INT_MAX;
+  return drive_imu_get();
 }
 
 double Drive::drive_tick_per_inch() {
@@ -412,20 +414,32 @@ bool Drive::drive_current_left_over() { return left_motors.front().is_over_curre
 void Drive::drive_imu_reset(double new_heading) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  for (int i = 0; i < good_imus.size(); i++) {
+  for (int i = 0; i < all_imus.size(); i++) {
     // Reads go through get_this_imu(), which multiplies by the scaler, so the
     // value written here has to be divided by it to read back as new_heading
-    auto scaler = imu_scale_map.find(good_imus[i]->get_port());
+    auto scaler = imu_scale_map.find(all_imus[i]->get_port());
     double scale = (scaler != imu_scale_map.end() && scaler->second != 0.0) ? scaler->second : 1.0;
-    good_imus[i]->set_rotation(new_heading / scale);
+    all_imus[i]->set_rotation(new_heading / scale);
   }
   angle_rad = util::to_rad(new_heading);
   t_last = -angle_rad;
+  last_good_angle = new_heading;
 }
 double Drive::get_this_imu(pros::Imu* imu) { return imu->get_rotation() * imu_scale_map[imu->get_port()]; }
 
-double Drive::drive_imu_get() { return get_this_imu(imu); }
+double Drive::drive_imu_get() {
+  if (imu == nullptr) return last_good_angle;
+
+  double reading = get_this_imu(imu);
+  if (std::isfinite(reading)) {
+    last_good_angle = reading;
+    return reading;
+  }
+  return last_good_angle;
+}
 double Drive::drive_imu_accel_get() {
+  if (imu == nullptr) return 0.0;
+
   auto accel = imu->get_accel();
   return std::hypot(accel.x, accel.y);
 }
@@ -439,8 +453,8 @@ double Drive::drive_imu_scaler_get() { return imu_scale_map[imu->get_port()]; }
 void Drive::drive_imus_scalers_set(std::vector<double> scales) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  for (int i = 0; i < std::min(good_imus.size(), scales.size()); i++) {
-    imu_scale_map[good_imus[i]->get_port()] = scales[i];
+  for (int i = 0; i < std::min(all_imus.size(), scales.size()); i++) {
+    imu_scale_map[all_imus[i]->get_port()] = scales[i];
   }
 }
 std::map<int, double> Drive::drive_imus_scalers_get() { return imu_scale_map; }
@@ -478,7 +492,16 @@ void Drive::drive_imu_display_loading(int iter) {
 
 bool Drive::drive_imu_calibrate(bool run_loading_animation) {
   imu_calibration_complete = false;
+  imu_calibrate_took_too_long = false;
   bool one_calibrated = false;
+
+  {
+    // Reset the IMU watchdog for this calibration
+    std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+    imu_stuck_passes.clear();
+    imu_healthy_passes.clear();
+    imu_only_imu_warning_shown = false;
+  }
 
   // No IMUs are calibrated yet, set them all to false
   std::map<int, bool> imus_status, imus_done, imus_last_status;
@@ -521,7 +544,6 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
     if (iter >= 2000) {
       if (successful) {
         printf("IMU is done calibrating (took %d ms)\n", iter);
-        imu_calibrate_took_too_long = iter > 2000 ? true : false;
         break;
       }
       if (iter >= 3000) {
@@ -548,21 +570,15 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
   {
     std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-    for (int i = 0; i < good_imus.size(); i++) {
-      int port = good_imus[i]->get_port();
+    good_imus.erase(std::remove_if(good_imus.begin(), good_imus.end(),
+                                    [&](pros::Imu* n) { return !imus_done[n->get_port()]; }),
+                     good_imus.end());
 
-      if (!imus_done[port]) {
-        good_imus.erase(good_imus.begin() + i);
-        if (i == 0 && !good_imus.empty())
-          imu = good_imus.front();
-      }
-    }
+    imu = good_imus.empty() ? nullptr : good_imus.front();
 
     if (one_calibrated && !good_imus.empty())
       imu_calibration_complete = true;
   }
-
-  printf("one cali-%i\n", one_calibrated);
 
   return imu_calibration_complete;
 }

--- a/src/EZ-Template/drive/maintenance.cpp
+++ b/src/EZ-Template/drive/maintenance.cpp
@@ -4,28 +4,119 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <algorithm>
+#include <cmath>
+
 #include "EZ-Template/drive/drive.hpp"
 #include "EZ-Template/util.hpp"
 #include "api.h"
 
 using namespace ez;
 
+// Consecutive passes (at util::DELAY_TIME per pass) a moving drive's IMU
+// reading can stay unchanged before it's considered stuck.
+constexpr int IMU_STUCK_PASSES_THRESHOLD = 50;  // 500 ms
+// Consecutive healthy passes an ejected IMU needs before it's trusted again.
+constexpr int IMU_REACTIVATE_PASSES_THRESHOLD = 100;  // 1000 ms
+// Minimum drive sensor movement (in) between passes to consider the robot moving.
+constexpr double IMU_DRIVE_MOTION_THRESHOLD_IN = 0.05;
+
 void Drive::check_imu_task() {
   // Don't let this function run if IMU calibration is incomplete
   if (!imu_calibration_complete) return;
 
-  // Erase indices only if imu val equals previous one
-  good_imus.erase(std::remove_if(good_imus.begin(), good_imus.end(), [this](pros::Imu *n) { return n->get_status() == pros::ImuStatus::error /*|| errno == PROS_ERR*/ || prev_imu_values[n->get_port()].second >= 5; }), good_imus.end());
+  // Figure out if the drive has physically moved since the last pass.  A
+  // stationary, deadbanded IMU reading the same value pass after pass is
+  // normal and must never be mistaken for a stuck sensor.
+  double l_now = drive_sensor_left();
+  double r_now = drive_sensor_right();
+  bool moved = std::fabs(l_now - watchdog_l_last) > IMU_DRIVE_MOTION_THRESHOLD_IN ||
+               std::fabs(r_now - watchdog_r_last) > IMU_DRIVE_MOTION_THRESHOLD_IN;
+  watchdog_l_last = l_now;
+  watchdog_r_last = r_now;
 
-  // Increment every time an IMU doesn't update
+  // Update each currently-good IMU's stuck-pass counter
   for (size_t i = 0; i < good_imus.size(); i++) {
-    if (prev_imu_values[good_imus[i]->get_port()].first == get_this_imu(good_imus[i]))
-      prev_imu_values[good_imus[i]->get_port()].second += 1;
-    else
-      prev_imu_values[good_imus[i]->get_port()].second = 0;
-    prev_imu_values[good_imus[i]->get_port()].first = get_this_imu(good_imus[i]);
+    pros::Imu* n = good_imus[i];
+    int port = n->get_port();
+    double reading = get_this_imu(n);
+
+    if (n->is_installed() && std::isfinite(reading)) {
+      bool unchanged = reading == prev_imu_values[port].first;
+      if (moved && unchanged)
+        imu_stuck_passes[port] += 1;
+      else
+        imu_stuck_passes[port] = 0;
+    }
+
+    prev_imu_values[port].first = reading;
   }
 
-  if (!good_imus.empty())
+  // An IMU is bad if it's unplugged, its reading isn't finite, or it's been
+  // stuck (unchanged while the drive moved) for too many passes in a row.
+  auto is_bad = [this](pros::Imu* n) {
+    int port = n->get_port();
+    return !n->is_installed() || !std::isfinite(prev_imu_values[port].first) ||
+           imu_stuck_passes[port] >= IMU_STUCK_PASSES_THRESHOLD;
+  };
+
+  // Never eject the last remaining good IMU, even if it looks unhealthy.
+  int bad_count = 0;
+  for (auto* n : good_imus) {
+    if (is_bad(n)) bad_count++;
+  }
+  bool keep_front = bad_count > 0 && bad_count == static_cast<int>(good_imus.size());
+  if (keep_front && !imu_only_imu_warning_shown) {
+    printf("EZ-Template: IMU on port %d looks unhealthy but it is the only IMU, keeping it\n", good_imus.front()->get_port());
+    imu_only_imu_warning_shown = true;
+  }
+
+  bool skipped_front = false;
+  good_imus.erase(std::remove_if(good_imus.begin(), good_imus.end(),
+                                  [&](pros::Imu* n) {
+                                    if (!is_bad(n)) return false;
+                                    if (keep_front && !skipped_front) {
+                                      skipped_front = true;
+                                      return false;
+                                    }
+                                    return true;
+                                  }),
+                   good_imus.end());
+
+  // Give ejected IMUs a chance to prove they've recovered before trusting
+  // them again.  They're re-added at the back so the primary doesn't flip
+  // back and forth.
+  for (pros::Imu* n : all_imus) {
+    if (std::find(good_imus.begin(), good_imus.end(), n) != good_imus.end()) continue;
+
+    int port = n->get_port();
+    double reading = get_this_imu(n);
+    bool healthy_this_pass = n->is_installed() && std::isfinite(reading) && reading != prev_imu_values[port].first;
+
+    if (healthy_this_pass)
+      imu_healthy_passes[port] += 1;
+    else
+      imu_healthy_passes[port] = 0;
+
+    prev_imu_values[port].first = reading;
+
+    if (imu_healthy_passes[port] >= IMU_REACTIVATE_PASSES_THRESHOLD) {
+      // Align the recovered IMU to the current heading before it can be
+      // switched to, so doing so doesn't jump the reported heading.
+      auto scaler = imu_scale_map.find(port);
+      double scale = (scaler != imu_scale_map.end() && scaler->second != 0.0) ? scaler->second : 1.0;
+      n->set_rotation(drive_imu_get() / scale);
+
+      good_imus.push_back(n);
+      imu_healthy_passes[port] = 0;
+      imu_stuck_passes[port] = 0;
+      printf("EZ-Template: IMU on port %d recovered\n", port);
+    }
+  }
+
+  // Keep the primary IMU pointed at the front of the healthy deque
+  if (!good_imus.empty() && good_imus.front() != imu) {
     imu = good_imus.front();
+    printf("EZ-Template: switching primary IMU to port %d\n", imu->get_port());
+  }
 }


### PR DESCRIPTION
What was wrong

check_imu_task() (src/EZ-Template/drive/maintenance.cpp) ejected an IMU from good_imus whenever its scaled rotation read exactly equal to the previous pass five times in a row (50 ms), or when get_status() equaled ImuStatus::error, a value an unplugged sensor does not actually return (it returns the raw PROS_ERR_F sentinel). A V5 IMU sitting still is deadbanded and can read identically for long stretches, so this could eject every IMU while the robot just sat on the field. Nothing ever re-added an ejected IMU. Once good_imus was empty, imu still pointed at the erased object so heading reads kept working and hid the problem, but drive_imu_reset(), drive_angle_set(), odom_theta_set(), and drive_imus_scalers_set() all loop over good_imus and would silently do nothing, while drive_imu_calibrated() on an empty deque still reported success.

drive_imu_calibrate() (src/EZ-Template/drive/drive.cpp) had an erase-while-iterating loop over good_imus that could skip the element right after an erasure, only re-pointed imu when index 0 was the one erased, and never nulled imu out, so drive_angle_get()'s old return INT_MAX path was unreachable (and would have been a dangerous sentinel value if it were ever reached). drive_defaults_set() called imu->set_data_rate(5) N times instead of setting it once per IMU. imu_calibrate_took_too_long was being set from iter > 2000 on the success path, which marks an entirely normal 2.1 s calibration as "took too long" and makes drive_imu_calibrated() report false after a clean boot. There was a leftover debug printf("one cali-%i\n", ...). The destructor deleted imu directly and then called good_imus.pop_front(), which assumes good_imus.front() is always the same object as imu and can pop or delete the wrong element once the primary has been reassigned.

What this change does

Rewrote the IMU watchdog so it distinguishes "the robot is holding still" from "this IMU is actually stuck":
- check_imu_task() now compares drive_sensor_left()/drive_sensor_right() against the previous pass to decide whether the drive physically moved (more than 0.05 in on either side). An IMU's stuck-pass counter only increments when the drive moved and the IMU's reading did not change; it resets to 0 otherwise. A stationary, deadbanded IMU can no longer be ejected just for reading the same value while the robot sits still.
- An IMU is also flagged bad if it reports not installed, or its scaled reading is non-finite (this correctly catches an unplugged sensor, since PROS's rotation getter returns PROS_ERR_F/INFINITY on error).
- The stuck threshold is 50 consecutive bad passes (500 ms); the last remaining IMU in good_imus is never ejected, even if it looks unhealthy — a one-time message is printed instead.
- Added a private all_imus deque that holds every IMU ever constructed and never shrinks. Every constructor pushes into it alongside good_imus; the destructor now deletes through all_imus and clears both deques instead of popping a possibly-empty good_imus.
- Ejected IMUs are now given a chance to recover: for every IMU in all_imus not currently in good_imus, if it reports installed with a finite, changing reading for 100 consecutive passes (1 s), it is re-added at the back of good_imus (so it can't flap the primary back and forth), after first calling set_rotation() to align it to the current heading so switching to it later doesn't jump the reported angle.
- The primary imu pointer is kept synced to good_imus.front() every pass, printing when the primary changes.
- drive_imu_reset() and drive_imus_scalers_set() now iterate all_imus instead of good_imus, so an IMU that was temporarily ejected and later recovers has the correct rotation offset and scaler already applied.
- drive_angle_get()/drive_imu_get() now fall back to a stored last_good_angle when imu is null or the live reading is non-finite, instead of the previous unreachable INT_MAX sentinel. drive_imu_accel_get() returns 0.0 when imu is null.
- drive_imu_calibrate()'s removal loop is now a straightforward erase(remove_if) over good_imus keyed off which ports finished calibrating, followed by imu = good_imus.empty() ? nullptr : good_imus.front(), removing the erase-while-iterating bug and guaranteeing imu is never left dangling.
- imu_calibrate_took_too_long is now only set true on the 3000 ms failsafe path, and is reset to false (along with the watchdog's stuck/healthy pass counters and its one-time "only IMU" warning flag) at the start of every calibration, so a normal calibration that takes a bit over 2 s no longer makes drive_imu_calibrated() report false, and a prior failure doesn't linger into a later successful calibration.
- drive_defaults_set() now calls good_imus[i]->set_data_rate(5) inside its loop instead of calling it on the primary IMU N times.
- Removed the leftover printf("one cali-%i\n", ...) debug line.
- Everything that touches good_imus, all_imus, imu, or the new tracking maps continues to run under the existing drive_mutex, following the same pattern already used by drive_imu_reset(), drive_imus_scalers_set(), and the calibrate removal loop.

How this was verified

pros make builds clean with no warnings or errors from these changes; drive.cpp.o and maintenance.cpp.o both rebuilt and the firmware linked successfully. This was reviewed against the current source in src/EZ-Template/drive/maintenance.cpp, src/EZ-Template/drive/drive.cpp, and include/EZ-Template/drive/drive.hpp (the file layout has moved since the original audit; there is no other check_imu_task() or drive_imu_calibrate() elsewhere in the tree). I do not have hardware to run the actual watchdog behavior against, so the checklist below is for the maintainer to run before merging.

Audit IDs: H7, M1

Hardware checklist for the maintainer

1. Two IMUs plugged in, robot at rest on a table for two minutes: good_imus.size() should stay at 2 the whole time (no ejections from deadbanded readings).
2. While driving, unplug the second (non-primary) IMU: within about 1 second the terminal should print that the port is being dropped. Re-plug it: within a few seconds a "recovered" message should print and good_imus.size() should return to 2.
3. While driving, unplug the first (primary) IMU instead: a "switching primary IMU" message should print, and the reported heading should continue without a jump larger than the normal drift between the two sensors.
4. Single-IMU robot: unplug the only IMU while driving. Heading should freeze at the last good value, there should be no crash, and the "only IMU" message should print exactly once (not repeatedly).
5. drive_imu_calibrated() should return true after a normal boot/calibration (no false "took too long" report).

Note on scope: the spec for this fix says imu_calibrate_took_too_long should become true only on the 3000 ms failsafe path. Making that hold up across repeated calibration attempts (e.g. recalibrating after a previous failed calibration) requires resetting it to false at the start of drive_imu_calibrate(), which isn't explicitly listed in the task description but is included here since otherwise a single prior failure would permanently latch drive_imu_calibrated() to false. Everything else matches the described design; I did not find any other deviations worth flagging.

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 30482d4f0db3a726bf3bca8f5b2a2a8f817b1a13 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34078120172)
- via manual download: [EZ-Template@4.0.0+30482d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002765769.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+30482d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002765769.zip;
pros c fetch EZ-Template@4.0.0+30482d.zip;
pros c apply EZ-Template@4.0.0+30482d;
rm EZ-Template@4.0.0+30482d.zip;
```