### PR TITLE
Fix turn/swing min-output gate using compass heading instead of turn size

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3102,7 +3102,8 @@ class Drive {
   double pid_drive_chain_backward_constant_get();
 
   /**
-   * Sets minimum power for swings when kI and startI are enabled.
+   * When kI and startI are enabled, sets the maximum output allowed while error is inside
+   * startI, for swings larger than startI. This lets I accumulate without overshoot.
    *
    * \param min
    *        new clipped speed
@@ -3110,7 +3111,8 @@ class Drive {
   void pid_swing_min_set(int min);
 
   /**
-   * The minimum power for turns when kI and startI are enabled.
+   * When kI and startI are enabled, sets the maximum output allowed while error is inside
+   * startI, for turns larger than startI. This lets I accumulate without overshoot.
    *
    * \param min
    *        new clipped speed
@@ -3118,12 +3120,14 @@ class Drive {
   void pid_turn_min_set(int min);
 
   /**
-   * Returns minimum power for swings when kI and startI are enabled.
+   * Returns the maximum output allowed while error is inside startI, for swings larger than startI,
+   * when kI and startI are enabled.
    */
   int pid_swing_min_get();
 
   /**
-   * Returns minimum power for turns when kI and startI are enabled.
+   * Returns the maximum output allowed while error is inside startI, for turns larger than startI,
+   * when kI and startI are enabled.
    */
   int pid_turn_min_get();
 

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -116,8 +116,8 @@ void Drive::turn_pid_task() {
   // Clip gyroPID to max speed
   double gyro_out = util::clamp(turnPID.output, slew_turn.output(), -slew_turn.output());
 
-  // Clip the speed of the turn when the robot is within StartI, only do this when target is larger then StartI
-  if (turnPID.constants.ki != 0 && (fabs(turnPID.target_get()) > turnPID.constants.start_i && fabs(turnPID.error) < turnPID.constants.start_i)) {
+  // Clip the speed of the turn when the robot is within StartI, only do this when the turn is larger then StartI
+  if (turnPID.constants.ki != 0 && (fabs(chain_target_start - chain_sensor_start) > turnPID.constants.start_i && fabs(turnPID.error) < turnPID.constants.start_i)) {
     if (pid_turn_min_get() != 0)
       gyro_out = util::clamp(gyro_out, pid_turn_min_get(), -pid_turn_min_get());
   }
@@ -141,8 +141,8 @@ void Drive::swing_pid_task() {
   // Clip swingPID to max speed
   double swing_out = util::clamp(swingPID.output, slew_swing.output(), -slew_swing.output());
 
-  // Clip the speed of the turn when the robot is within StartI, only do this when target is larger then StartI
-  if (swingPID.constants.ki != 0 && (fabs(swingPID.target_get()) > swingPID.constants.start_i && fabs(swingPID.error) < swingPID.constants.start_i)) {
+  // Clip the speed of the swing when the robot is within StartI, only do this when the swing is larger then StartI
+  if (swingPID.constants.ki != 0 && (fabs(chain_target_start - chain_sensor_start) > swingPID.constants.start_i && fabs(swingPID.error) < swingPID.constants.start_i)) {
     if (pid_swing_min_get() != 0)
       swing_out = util::clamp(swing_out, pid_swing_min_get(), -pid_swing_min_get());
   }

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -11,7 +11,7 @@ namespace ez {
 /////
 // Sets swing constants
 /////
-// Max speed when i is enabled for large turns
+// When kI and startI are enabled, maximum output allowed while error is inside startI, for swings larger than startI
 void Drive::pid_swing_min_set(int min) { swing_min = abs(min); }
 int Drive::pid_swing_min_get() { return swing_min; }
 


### PR DESCRIPTION
## Audit ID

M4

## What was wrong

`pid_turn_min_set`/`pid_swing_min_set` clip the PID output to a floor/ceiling while the robot is inside `startI`, but the doc comment said this only applies to motions "larger than startI" so that momentum isn't lost on small moves. The problem is how "larger than startI" was decided.

In `turn_pid_task()` and `swing_pid_task()` (`src/EZ-Template/drive/pid_tasks.cpp`), the gate compared `fabs(turnPID.target_get())` (and `fabs(swingPID.target_get())`) against `start_i`. `target_get()` is the absolute destination heading on the compass, not the size of the turn actually being made. That means the gate fires based on where the robot ends up facing, not on how far it turned to get there.

Worked example with `start_i = 15`:

- Robot at 175 degrees, `pid_turn_set(0)` -> an actual 175-degree turn. Old gate: `fabs(target_get()) = fabs(0) = 0`, which is not `> 15`, so the cap was skipped on exactly the large turn the feature exists to protect. New gate: `fabs(chain_target_start - chain_sensor_start) = fabs(0 - 175) = 175 > 15`, so the cap correctly applies.
- Robot at 88 degrees, `pid_turn_set(90)` -> an actual 2-degree turn. Old gate: `fabs(target_get()) = fabs(90) = 90 > 15`, so the cap was applied on a 2-degree turn where it shouldn't matter. New gate: `fabs(90 - 88) = 2`, not `> 15`, so the cap correctly does not apply.

Same logic and same bug affected swings via `swingPID.target_get()`.

## What the change does

In both `turn_pid_task()` and `swing_pid_task()`, the gate condition is replaced with `fabs(chain_target_start - chain_sensor_start) > start_i`, i.e. the actual signed size of the turn/swing from where it started to where it's headed, rather than the absolute compass heading of the destination. `chain_target_start` and `chain_sensor_start` are already set by `pid_turn_set`/`pid_swing_set` (in `src/EZ-Template/drive/set_pid/set_turn_pid.cpp` and `set_swing_pid.cpp`) immediately before `drive_mode_set`, for plain turns, turn-to-point, and swings alike, so no new state or setter is needed. This is also the same idiom `exit_conditions.cpp` already uses (`chain_target_start - chain_sensor_start`) for signed turn-chain scaling, so the fix follows an existing convention rather than introducing a new one.

This is a gate-condition and documentation fix only. The clamp itself (`util::clamp(gyro_out, min, -min)` / `util::clamp(swing_out, min, -min)`) is unchanged, per the maintainer's decision to keep it as a cap rather than turning it into a real floor. The Doxygen for `pid_turn_min_set`, `pid_swing_min_set`, `pid_turn_min_get`, `pid_swing_min_get` in `include/EZ-Template/drive/drive.hpp`, and the matching plain comment above `pid_swing_min_set` in `set_swing_pid.cpp`, are rewritten to describe this as the maximum output allowed while error is inside startI (when kI and startI are enabled) for turns/swings larger than startI, so I can accumulate without overshoot, instead of calling it a "minimum". The inline comments in `pid_tasks.cpp` above the gate were also updated from "when target is larger than StartI" to "when the turn/swing is larger than StartI" to stop describing the old, incorrect condition.

One clarification worth noting: for `TURN_TO_POINT`, `pid_turn_set` computes and stores `chain_target_start`/`chain_sensor_start` once at the start of the motion (turn-to-point re-targets each iteration via `point_to_face`, but the initial call into `pid_turn_set` still snapshots the starting values before `drive_mode_set(TURN_TO_POINT)`). The gate therefore reflects the turn size at motion start, which is the intended reading of "how big is this turn," not a moving target.

Not touched: `EZ-Template-Example-Project/include/EZ-Template/drive/drive.hpp` carries its own stale copy of these Doxygen comments. Per repo convention that file is regenerated from the release tag by CI and not hand-edited, so it intentionally still has the old wording until the next release cut.

## How I verified it

- Found the current gate logic by grepping for `turn_pid_task`/`swing_pid_task` (now in `src/EZ-Template/drive/pid_tasks.cpp`) and for `chain_target_start`/`chain_sensor_start` (set in `src/EZ-Template/drive/set_pid/set_turn_pid.cpp` and `set_swing_pid.cpp`, and also read in `src/EZ-Template/drive/exit_conditions.cpp`), confirming both are shared, plain `double` members used identically for turn and swing (no separate swing-specific chain variable names).
- Reasoned through the worked numeric examples above to confirm the new gate reflects actual turn/swing size instead of absolute destination heading, in both directions (false negative and false positive fixed).
- Ran `pros make` from the repo root after all edits: full clean build succeeded (all `.cpp` files compiled `[OK]`, `bin/cold.package.elf` and `bin/hot.package.bin` produced, exit code 0). A re-run afterward reported "Nothing to be done for 'quick'", confirming the tree was already built clean with these changes in place.

## Hardware checklist for the maintainer

This is a gate-condition-and-docs fix, not a clamp/tuning change, so no numeric retuning is expected. Please confirm on hardware:

1. A turn or swing that ends near 0/360 degrees but is itself a large motion (e.g. turning from ~175 degrees to 0) now gets the min-output cap applied appropriately during startI, where before it may have been skipped.
2. A turn or swing that is itself small but ends at a heading far from 0 (e.g. turning from 88 to 90 degrees) is no longer clamped to the min output during startI, where before it may have been unnecessarily capped.
3. Existing autons that already rely on `pid_turn_min_set`/`pid_swing_min_set` for large turns behave the same in the tuning sense (same output ceiling once inside startI, same overshoot-prevention behavior) for the large-turn cases that were already being gated correctly before this fix.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 13a3811a9731d502dc68d4c7d722a586e2f162be -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34078203012)
- via manual download: [EZ-Template@4.0.0+13a381.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002789610.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+13a381.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002789610.zip;
pros c fetch EZ-Template@4.0.0+13a381.zip;
pros c apply EZ-Template@4.0.0+13a381;
rm EZ-Template@4.0.0+13a381.zip;
```