### PR TITLE
Fix mirrored autons double-flipping turn/swing headings

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3616,6 +3616,10 @@ class Drive {
   double turn_right(double target, double current, bool print = false);
   bool imu_calibration_complete = false;
   bool is_swing_slew_enabled(e_swing type, double target, double current);
+  // Converts a user-facing swing side to the internal side (mirrored when theta is flipped).
+  e_swing swing_type_internal(e_swing type);
+  // Runs the swing base with already-internal-frame type/target.  Does not flip.
+  void swing_set_internal(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on);
   bool slew_reenables_when_max_speed_changes = true;
   int slew_min_when_it_enabled = 0;
   bool slew_will_enable_later = false;
@@ -3635,6 +3639,10 @@ class Drive {
   bool x_flipped = false;
   bool theta_flipped = false;
   double flip_angle_target(double target);
+  // Runs the turn base with an already-internal-frame target.  Does not flip.
+  void turn_set_internal(double target, int speed, e_angle_behavior behavior, bool slew_on);
+  // The current heading target expressed in the user's frame (undoes the internal flip).
+  double heading_target_user_frame();
   double odom_imu_start = 0.0;
   int past_target = 0;
   double SPACING = 0.5;
@@ -3730,6 +3738,8 @@ class Drive {
    */
   void wait_until_drive(double target);
   void wait_until_turn_swing(double target);
+  // Expects an already-resolved, internal-frame absolute target.  Does not flip or re-resolve behavior.
+  void wait_until_turn_swing_internal(double target);
 
   /**
    * Sets the chassis to voltage.

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -246,14 +246,18 @@ void Drive::wait_until_drive(double target) {
 
 // Function to wait until a certain position is reached.  Wrapper for exit condition.
 void Drive::wait_until_turn_swing(double target) {
+  // Flip into the internal frame and resolve using the motion's own behavior
+  target = new_turn_target_compute(flip_angle_target(target), drive_angle_get(), current_angle_behavior);
+  wait_until_turn_swing_internal(target);
+}
+
+// Expects an already-resolved, internal-frame absolute target.  Does not flip or re-resolve behavior.
+void Drive::wait_until_turn_swing_internal(double target) {
   // Make sure mode is correct
   if (!(mode == TURN || mode == SWING || mode == TURN_TO_POINT)) {
     printf("Mode needs to be swing or turn!\n");
     return;
   }
-
-  // Create new target that is the shortest from current
-  target = new_turn_target_compute(target, drive_angle_get(), shortest);
 
   // Calculate error between current and target (target needs to be an in between position)
   double g_error = target - drive_angle_get();
@@ -438,7 +442,11 @@ void Drive::pid_wait_quick() {
   } else if (mode == POINT_TO_POINT) {
     pid_wait_until_point(odom_target_start);
     return;
-  } else if (!(mode == DRIVE || mode == TURN || mode == SWING || mode == TURN_TO_POINT)) {
+  } else if (mode == TURN || mode == SWING || mode == TURN_TO_POINT) {
+    // chain_target_start is already internal-frame and already behavior-resolved
+    wait_until_turn_swing_internal(chain_target_start);
+    return;
+  } else if (mode != DRIVE) {
     printf("Not in a valid drive mode!\n");
     return;
   }

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -83,10 +83,19 @@ void Drive::slew_swing_forward_set(bool slew_on) { global_forward_swing_slew_ena
 bool Drive::slew_swing_forward_get() { return global_forward_swing_slew_enabled; }
 void Drive::slew_swing_backward_set(bool slew_on) { global_backward_swing_slew_enabled = slew_on; }
 bool Drive::slew_swing_backward_get() { return global_backward_swing_slew_enabled; }
+// Converts a user-facing swing side to the internal side (mirrored when theta is flipped)
+e_swing Drive::swing_type_internal(e_swing type) {
+  if (odom_theta_direction_get())
+    return type == ez::LEFT_SWING ? ez::RIGHT_SWING : ez::LEFT_SWING;
+  return type;
+}
+
 // Checks if slew is globally enabled or not
 bool Drive::is_swing_slew_enabled(e_swing type, double target, double current) {
-  int side = type == ez::LEFT_SWING ? 1 : -1;
-  int direction = util::sgn((target - current) * side);
+  e_swing internal_type = swing_type_internal(type);
+  double internal_target = flip_angle_target(target);
+  int side = internal_type == ez::LEFT_SWING ? 1 : -1;
+  int direction = util::sgn((internal_target - current) * side);
   return direction == 1 ? slew_swing_forward_get() : slew_swing_backward_get();
 }
 
@@ -109,7 +118,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed) {
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed) {
   // Figure out if going forward or backward
-  double absolute_heading = target + headingPID.target_get();
+  double absolute_heading = target + heading_target_user_frame();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, 0, pid_swing_behavior_get(), slew_on);
 }
@@ -133,7 +142,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, e_ang
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, e_angle_behavior behavior) {
   // Figure out if going forward or backward
-  double absolute_heading = target + headingPID.target_get();
+  double absolute_heading = target + heading_target_user_frame();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, 0, behavior, slew_on);
 }
@@ -157,7 +166,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 }
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed) {
-  double absolute_heading = target + headingPID.target_get();
+  double absolute_heading = target + heading_target_user_frame();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, opposite_speed, pid_swing_behavior_get(), slew_on);
 }
@@ -201,7 +210,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 }
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior) {
-  double absolute_heading = target + headingPID.target_get();
+  double absolute_heading = target + heading_target_user_frame();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, opposite_speed, behavior, slew_on);
 }
@@ -224,7 +233,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed, bool slew_on) {
   // Compute absolute target by adding to current heading
-  double absolute_target = headingPID.target_get() + target;
+  double absolute_target = heading_target_user_frame() + target;
   if (print_toggle) printf("Relative ");
   pid_swing_set(type, absolute_target, speed, opposite_speed, pid_swing_behavior_get(), slew_on);
 }
@@ -247,7 +256,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, e_ang
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, e_angle_behavior behavior, bool slew_on) {
   // Compute absolute target by adding to current heading
-  double absolute_target = headingPID.target_get() + target;
+  double absolute_target = heading_target_user_frame() + target;
   if (print_toggle) printf("Relative ");
   pid_swing_set(type, absolute_target, speed, 0, behavior, slew_on);
 }
@@ -267,7 +276,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
   // Compute absolute target by adding to current heading
-  double absolute_target = headingPID.target_get() + target;
+  double absolute_target = heading_target_user_frame() + target;
   if (print_toggle) printf("Relative ");
   pid_swing_set(type, absolute_target, speed, opposite_speed, behavior, slew_on);
 }
@@ -280,6 +289,13 @@ void Drive::pid_swing_relative_set(e_swing type, okapi::QAngle p_target, int spe
 // Swing set base
 /////
 void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
+  swing_set_internal(swing_type_internal(type), flip_angle_target(target), speed, opposite_speed, behavior, slew_on);
+}
+
+/////
+// Swing set internal
+/////
+void Drive::swing_set_internal(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
   interfered = false;
@@ -293,7 +309,6 @@ void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_s
   current_angle_behavior = behavior;
 
   // Compute new turn target based on new angle
-  target = flip_angle_target(target);
   target = new_turn_target_compute(target, drive_angle_get(), current_angle_behavior);
 
   // Print targets
@@ -303,13 +318,10 @@ void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_s
   chain_target_start = target;
   used_motion_chain_scale = 0.0;
 
-  // Flip the swing from left-right if rotation axis is flipped
   current_swing = type;
-  if (odom_theta_direction_get())
-    current_swing = current_swing == ez::LEFT_SWING ? ez::RIGHT_SWING : ez::LEFT_SWING;
 
   // Figure out if going forward or backward
-  int side = type == ez::LEFT_SWING ? 1 : -1;
+  int side = current_swing == ez::LEFT_SWING ? 1 : -1;
   int direction = util::sgn((target - chain_sensor_start) * side);
 
   // Set constants according to the robots direction

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -37,6 +37,9 @@ double Drive::flip_angle_target(double target) {
   return new_target;
 }
 
+// The current heading target expressed in the user's frame (undoes the internal flip)
+double Drive::heading_target_user_frame() { return flip_angle_target(headingPID.target_get()); }
+
 /////
 // Set turn PID basic wrappers
 /////
@@ -103,8 +106,8 @@ void Drive::pid_turn_set(okapi::QAngle p_target, int speed, e_angle_behavior beh
 }
 // Relative
 void Drive::pid_turn_relative_set(double target, int speed, e_angle_behavior behavior, bool slew_on) {
-  // Compute absolute target by adding to current heading
-  double absolute_target = headingPID.target_get() + target;
+  // Compute absolute target by adding to current heading (both in the user's frame)
+  double absolute_target = heading_target_user_frame() + target;
   if (print_toggle) printf("Relative ");
   pid_turn_set(absolute_target, speed, behavior, slew_on);
 }
@@ -117,6 +120,13 @@ void Drive::pid_turn_relative_set(okapi::QAngle p_target, int speed, e_angle_beh
 // Turn to angle base
 /////
 void Drive::pid_turn_set(double target, int speed, e_angle_behavior behavior, bool slew_on) {
+  turn_set_internal(flip_angle_target(target), speed, behavior, slew_on);
+}
+
+/////
+// Turn to angle internal
+/////
+void Drive::turn_set_internal(double target, int speed, e_angle_behavior behavior, bool slew_on) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
   interfered = false;
@@ -128,7 +138,6 @@ void Drive::pid_turn_set(double target, int speed, e_angle_behavior behavior, bo
   current_angle_behavior = behavior;
 
   // Compute new turn target based on new angle
-  target = flip_angle_target(target);
   target = new_turn_target_compute(target, drive_angle_get(), current_angle_behavior);
 
   // Print targets
@@ -199,7 +208,7 @@ void Drive::pid_turn_set(pose itarget, drive_directions dir, int speed, e_angle_
   // ANGLE_ADDER_WAS_RESET = false;
 
   if (print_toggle) printf("Turn to Point PID Started... Target Point: (%.2f, %.2f) \n", itarget.x, itarget.y);
-  pid_turn_set(target, speed, behavior, slew_on);
+  turn_set_internal(target, speed, behavior, slew_on);
 
   drive_mode_set(TURN_TO_POINT);
 }


### PR DESCRIPTION
## What was wrong

Angles get flipped into the internal (odom-mirrored) frame in more than one place, so mirrored autons (`odom_x_flip(); odom_theta_flip();`) double-flip some headings:

- `pid_turn_set(pose, ...)` (turn-to-point base) flips the target point, computes the angle to it (already internal-frame), then handed that internal-frame value to the `pid_turn_set(double, ...)` base, which flipped it again before storing it in both `turnPID` and `headingPID`. The physical turn still lands correctly because `turn_pid_task` recomputes the live angle for `TURN_TO_POINT` from `point_to_face` and `odom_pose_get()` every pass, ignoring `turnPID.target_get()` — but `headingPID`'s stored target ends up mirrored, so the next `pid_drive_set` starts with a heading error and spins.
- `pid_turn_relative_set` and all three `pid_swing_relative_set` bases computed `headingPID.target_get() + target`, adding an internal-frame value to a user-frame delta before handing the sum to a base that flips the whole thing once more.
- The four `pid_swing_relative_set` wrappers that decide slew off `absolute_heading`, and `is_swing_slew_enabled(type, target, current)` itself, mixed a user-frame `type`/`target` with the real (internal-frame) current heading.
- In the swing base, `current_swing` was flipped when theta was flipped, but `side` was computed from the original unflipped `type`, so `direction` (which selects forward/backward constants, slew constants, and `motion_chain_backward`) came out inverted for mirrored swings.
- `wait_until_turn_swing(double target)` never flipped its argument and always resolved it with `shortest`, regardless of the motion's actual behavior (`cw`/`ccw`/`longest`/`raw`). `pid_wait_quick()` also fed it an already-internal, already-resolved `chain_target_start` through that same flip-and-resolve path.

Tracked as H5, H6, and M5 in the 4.0.0-beta.1 audit.

## What the change does

Establishes one rule: flip exactly once, at the public API boundary. Internal helpers now take already-internal-frame values and never call `flip_angle_target`/`flip_pose` themselves:

- New `Drive::turn_set_internal(...)` holds the old turn-base body minus its flip; the public `pid_turn_set(double, ...)` base is now one line that flips then calls it. `pid_turn_set(pose, ...)` calls `turn_set_internal` directly with the internal-frame angle it already computed, instead of re-entering the public base.
- New `Drive::swing_set_internal(...)` holds the old swing-base body minus its flip and its "mirror `current_swing`" block; `current_swing` is simply set to the (already internal) `type` parameter, and `side` is computed from `current_swing`. The public `pid_swing_set` base flips both `type` (via new `swing_type_internal`) and `target` before calling it.
- New `Drive::heading_target_user_frame()` returns `flip_angle_target(headingPID.target_get())` — the stored heading target undone back into the user's frame. All the relative bases (`pid_turn_relative_set`, all three `pid_swing_relative_set` overloads) and the four slew-decision wrappers now add the user's delta to this instead of to the raw internal `headingPID.target_get()`, then go back through the public (single-flip) base.
- `is_swing_slew_enabled` now converts its own `type`/`target` arguments to internal frame internally (`swing_type_internal`, `flip_angle_target`) before comparing against the real current heading.
- `wait_until_turn_swing_internal(double target)` holds the old wait-loop body verbatim, minus the `new_turn_target_compute(target, ..., shortest)` line, and expects an already-resolved internal-frame target. The public `wait_until_turn_swing(double target)` now does `new_turn_target_compute(flip_angle_target(target), drive_angle_get(), current_angle_behavior)` — flipping into the internal frame and resolving with the motion's real behavior instead of a hardcoded `shortest` — then calls the internal one. `pid_wait_quick()` calls `wait_until_turn_swing_internal(chain_target_start)` directly for `TURN`/`SWING`/`TURN_TO_POINT`, since `chain_target_start` is already internal-frame and already resolved; the `DRIVE` path (`pid_wait_until(chain_target_start)`) is untouched.

The `drive_mutex` guard travelled with the moved code: it's still the first statement of the real base in both `turn_set_internal` and `swing_set_internal` (the public wrappers that now precede them do no state mutation before calling in). `pid_wait_quick_chain` releases its own scoped lock before it reaches `wait_until_turn_swing_internal` via `pid_wait_quick`, so nothing is held across a `pros::delay`.

Grepped `src/` for every caller of the functions whose contract changed (`is_swing_slew_enabled`, `wait_until_turn_swing`, and the public `pid_turn_set`/`pid_swing_set` bases) to confirm no other internal caller was passing an already-internal-frame value into what is now a flip point; all callers outside the two `set_pid` files are in `src/autons.cpp`, calling the unaffected public API.

## Verification

`pros make` builds clean (all four touched files compile, full link succeeds, cold+hot packages produced). No unit test harness exists for this library, so the following is a hand-traced reasoning check using the actual resolver functions (`purepursuit_math.cpp`, `util::absolute_angle_to_point`, `util::turn_shortest`/`turn_longest`), not just re-stated expected values.

**1. `pid_turn_set({24_in, 24_in}, fwd, 90); pid_wait(); pid_drive_set(12_in, 90); pid_wait();`**
Unmirrored: angle to (24,24) from (0,0) is `atan2(24,24) = 45`. `headingPID` target = 45.
Mirrored (`odom_x_flip(); odom_theta_flip();`): `flip_pose` flips x only → point becomes (-24, 24); angle = `atan2(-24,24) = -45`. Before the fix, that -45 was handed to the old turn base, which flipped it again (`theta_flipped` → ×-1) to +45 before `headingPID.target_set()` — a stored target 90° off from the true heading the point-turn actually achieved (turn-to-point aims live off `point_to_face`/`odom_pose_get()` every pass, so the physical turn itself lands on -45 regardless). The next `pid_drive_set(12, 90)` would then start with a 90° heading error and spin. After the fix, `turn_set_internal` receives -45 directly with no re-flip, so `headingPID` target = -45, matching the physical heading — the drive starts with zero heading error and goes straight.

**2. `pid_turn_set(90_deg, 90); pid_wait(); pid_turn_relative_set(45_deg, 90); pid_wait();`**
Unmirrored: first turn stores `headingPID` = 90. Relative: `heading_target_user_frame() = 90`, `absolute_target = 90 + 45 = 135`, single flip (theta unflipped) → final target 135.
Mirrored: first turn: `pid_turn_set(90,...)` → `turn_set_internal(flip_angle_target(90) = -90, ...)`; `headingPID` = -90. Relative: `heading_target_user_frame() = flip_angle_target(-90) = 90` (the user-frame view, correctly recovering the "90" the user actually asked for), `absolute_target = 90 + 45 = 135`, then the single flip at the public base gives `flip_angle_target(135) = -135`. Final `headingPID` target = -135, matching the spec. Before the fix this path added the *internal* -90 to the user's 45 to get -45, then flipped once more to +45 — wrong by 180°.

**3. `pid_swing_set(ez::LEFT_SWING, 90_deg, 90, 45); pid_wait_quick_chain();`**
Mirrored: `is_swing_slew_enabled(LEFT_SWING, 90, 0)` → `swing_type_internal(LEFT_SWING) = RIGHT_SWING`, `flip_angle_target(90) = -90`, `side = -1`, `direction = sgn((-90-0)*-1) = +1` → forward slew selected. The base then runs `swing_set_internal(RIGHT_SWING, -90, ...)`: `current_swing = RIGHT_SWING`, `side = -1`, `direction = sgn((-90-0)*-1) = +1` → forward branch taken (`forward_drivePID`/`forward_swingPID`, `motion_chain_backward = false`). So the mirrored call becomes a RIGHT swing to -90 using the FORWARD constants and slew, as required. Before the fix, `side` was computed from the unflipped `type` (`LEFT_SWING` → `side = 1`), giving `direction = sgn((-90-0)*1) = -1` — the backward constants and slew, the wrong ones for the direction the (correctly mirrored) swing was actually travelling.

**4. `pid_turn_set(200_deg, 90, ez::cw); pid_wait_until(100_deg); /* mark */ pid_wait();`**
`new_turn_target_compute(200, 0, cw)` resolves to 200 (the only positive/"right" representation, since `turn_shortest(200,0) = -160` fails the `sgn == 1` check `turn_right` requires, so it falls through to `turn_longest = 200`).
With the spec's exact mark (100°): both the old hardcoded-`shortest` resolution and the new behavior-aware resolution happen to produce the same internal target (100), because 100° sits inside the ±180° window where `shortest` and `cw` agree — so this specific number pair does not, by itself, exercise the bug (the mark is reached correctly either way). To exercise the actual defect described in H6, the mark needs to sit past the point where `shortest` and the motion's real behavior diverge — e.g. the same turn with a mark at **190°**: old code resolves it via hardcoded `shortest` to `turn_shortest(190,0) = -170`, whose sign never matches the turn's real (positive) direction of travel, so `pid_wait_until` never sees the sign flip and degrades to the turnPID exit-condition failsafe instead of returning mid-turn. New code resolves the same mark via the turn's real `cw` behavior to `turn_right(190,0) = +190`, matching the direction of travel, so the mark is correctly detected as the robot passes 190° — well before the turn finishes at 200°.

## Out of scope — found, not fixed

`current_angle_behavior` (the raw `cw`/`ccw`/`longest`/`shortest`/`raw` enum) is stored and later reused **unflipped** in `turn_set_internal`, `swing_set_internal`, and now `wait_until_turn_swing` as well, while the angle passed alongside it is flipped. So a mirrored `cw` turn still resolves clockwise in the internal frame instead of mirroring to `ccw`. This is pre-existing, byte-for-byte unchanged by this diff (the same unflipped assignment existed in the original code), and is not in this item's "what is wrong" list, so it's called out here rather than fixed.

## Hardware checklist (for the maintainer)

1. Flash the shipped `combining_movements` auton and run it once with no mirroring calls.
2. Add `odom_x_flip(); odom_theta_flip();` (per the mirrored-auton docs) and run the same auton again.
3. Confirm the mirrored run is the mirror image of the unmirrored run (same shapes, opposite side of the field).
4. Specifically watch the transition into the final drive segment after a turn/turn-to-point: confirm there is no spin or heading correction at the start of that drive in the mirrored run (this is the H5 symptom this PR fixes).
5. If any swing motions are in the auton, confirm the mirrored run's swings pivot on the mirrored side (left swing mirrors to a right-side pivot) and don't visibly hesitate or reverse direction at the start (the H6/M5 symptom).
6. If any `pid_wait_until`/`pid_wait_quick` calls mid-turn exist in the auton or a test auton, confirm they release control at the expected intermediate heading rather than waiting for the full motion to finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3c56752c74ad26f737cd857f478f9a377b6dacb0 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34078314467)
- via manual download: [EZ-Template@4.0.0+3c5675.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002825470.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+3c5675.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10002825470.zip;
pros c fetch EZ-Template@4.0.0+3c5675.zip;
pros c apply EZ-Template@4.0.0+3c5675;
rm EZ-Template@4.0.0+3c5675.zip;
```