### PR TITLE
🐛Fix opcontrol getter copy-paste bugs and one-sided speed clamp

### DIFF
--- a/src/EZ-Template/drive/user_input.cpp
+++ b/src/EZ-Template/drive/user_input.cpp
@@ -97,11 +97,11 @@ void Drive::opcontrol_curve_buttons_right_set(pros::controller_digital_e_t decre
 }
 
 std::vector<pros::controller_digital_e_t> Drive::opcontrol_curve_buttons_left_get() {
-  return {l_decrease_.button, r_decrease_.button};
+  return {l_decrease_.button, l_increase_.button};
 }
 
 std::vector<pros::controller_digital_e_t> Drive::opcontrol_curve_buttons_right_get() {
-  return {r_decrease_.button, r_decrease_.button};
+  return {r_decrease_.button, r_increase_.button};
 }
 
 // Increase / decrease left and right curves
@@ -282,8 +282,8 @@ void Drive::opcontrol_joystick_threshold_iterate(int l_stick, int r_stick) {
   r_out *= (opcontrol_speed_max / 127.0);
 
   // Ensure output is within speed limit
-  l_out = l_out > opcontrol_speed_max ? opcontrol_speed_max : l_out;
-  r_out = r_out > opcontrol_speed_max ? opcontrol_speed_max : r_out;
+  l_out = util::clamp(l_out, opcontrol_speed_max);
+  r_out = util::clamp(r_out, opcontrol_speed_max);
 
   drive_set(l_out, r_out);
 }
@@ -321,7 +321,7 @@ void Drive::opcontrol_arcade_standard(e_type stick_type) {
   // Toggle for controller curve
   opcontrol_curve_buttons_iterate();
 
-  int fwd_stick, turn_stick;
+  int fwd_stick = 0, turn_stick = 0;
   // Check arcade type (split vs single, normal vs flipped)
   if (stick_type == SPLIT) {
     // Put the joysticks through the curve function
@@ -345,7 +345,7 @@ void Drive::opcontrol_arcade_flipped(e_type stick_type) {
   // Toggle for controller curve
   opcontrol_curve_buttons_iterate();
 
-  int turn_stick, fwd_stick;
+  int turn_stick = 0, fwd_stick = 0;
   // Check arcade type (split vs single, normal vs flipped)
   if (stick_type == SPLIT) {
     // Put the joysticks through the curve function


### PR DESCRIPTION
## What was wrong

In `src/EZ-Template/drive/user_input.cpp`:

1. `Drive::opcontrol_curve_buttons_left_get()` and `Drive::opcontrol_curve_buttons_right_get()` had copy-paste bugs. The left getter returned `{l_decrease_.button, r_decrease_.button}` (mixing left and right buttons), and the right getter returned `{r_decrease_.button, r_decrease_.button}` (the decrease button twice instead of decrease + increase).
2. `Drive::opcontrol_joystick_threshold_iterate(int l_stick, int r_stick)` only clamped the positive side of the output (`l_out > opcontrol_speed_max ? opcontrol_speed_max : l_out`), so negative speeds could exceed `-opcontrol_speed_max` uncontrolled.
3. `Drive::opcontrol_arcade_standard(e_type stick_type)` and `Drive::opcontrol_arcade_flipped(e_type stick_type)` declared `fwd_stick`/`turn_stick` locals without initializing them, so an out-of-enum `stick_type` value would leave them uninitialized (flagged by cppcheck as `legacyUninitvar`).

## What changed

1. Fixed the two getters to return the correct button pairs (`{l_decrease_.button, l_increase_.button}` and `{r_decrease_.button, r_increase_.button}`).
2. Replaced the one-sided clamp with the existing symmetric `util::clamp(double input, double max)` overload, which clamps to `[-|max|, |max|]`.
3. Initialized `fwd_stick`/`turn_stick` (and `turn_stick`/`fwd_stick` in the flipped variant) to `0` at declaration.

`Drive::opcontrol_curve_buttons_iterate()` in this same file was intentionally left untouched — a separate, not-yet-landed batch of changes modifies that specific function.

## Verification

`pros make` builds clean; `src/EZ-Template/drive/user_input.cpp` compiles with no warnings/errors and the full cold/hot package links successfully.

Audit ID M11 remainder.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 5d1bb033378420250f86712496655ae2b0b4ccb9 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34080428916)
- via manual download: [EZ-Template@4.0.0+5d1bb0.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003493224.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+5d1bb0.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003493224.zip;
pros c fetch EZ-Template@4.0.0+5d1bb0.zip;
pros c apply EZ-Template@4.0.0+5d1bb0;
rm EZ-Template@4.0.0+5d1bb0.zip;
```