### PR TITLE
Fix null IMU derefs and good_imus reset on recalibration

### DIFF
--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -446,9 +446,20 @@ double Drive::drive_imu_accel_get() {
 
 void Drive::drive_imu_scaler_set(double scaler) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+  if (imu == nullptr) {
+    if (all_imus.empty()) return;
+    imu_scale_map[all_imus.front()->get_port()] = scaler;
+    return;
+  }
   imu_scale_map[imu->get_port()] = scaler;
 }
-double Drive::drive_imu_scaler_get() { return imu_scale_map[imu->get_port()]; }
+double Drive::drive_imu_scaler_get() {
+  if (imu == nullptr) {
+    if (all_imus.empty()) return 1.0;
+    return imu_scale_map[all_imus.front()->get_port()];
+  }
+  return imu_scale_map[imu->get_port()];
+}
 
 void Drive::drive_imus_scalers_set(std::vector<double> scales) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
@@ -501,6 +512,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
     imu_stuck_passes.clear();
     imu_healthy_passes.clear();
     imu_only_imu_warning_shown = false;
+    good_imus = all_imus;
   }
 
   // No IMUs are calibrated yet, set them all to false


### PR DESCRIPTION
Follow-up to #358 (IMU watchdog rework), fixing two gaps that rework left behind in `src/EZ-Template/drive/drive.cpp`.

## What was wrong

1. **Null-pointer deref in `drive_imu_scaler_set`/`drive_imu_scaler_get`.** `Drive::drive_imu_calibrate()` sets `imu = nullptr` when every IMU fails calibration, but both scaler functions still unconditionally dereferenced `imu`. On a single-IMU robot whose IMU fails calibration, the first auton call to `drive_imu_scaler_set` (or `drive_imu_scaler_get`) crashed with a null-pointer dereference.

2. **`good_imus` never reset on re-calibration.** `drive_imu_calibrate()` iterates `good_imus` throughout, but nothing repopulated it from `all_imus` before that happened. So if the watchdog had already ejected an IMU from `good_imus` earlier in the same boot, a second call to `drive_imu_calibrate()` could never retry that IMU, even if it had since been re-plugged.

## What changed

- `drive_imu_scaler_set`/`drive_imu_scaler_get` now guard against `imu == nullptr`, falling back to `all_imus.front()->get_port()` when `all_imus` is non-empty, otherwise returning early (setter) or returning `1.0` (getter).
- `drive_imu_calibrate()` now does `good_imus = all_imus;` inside the existing locked block at the top of the function that resets the watchdog state, so every calibration pass starts from the full IMU roster and can retry a previously ejected IMU.

Both changes are scoped to `src/EZ-Template/drive/drive.cpp` only — no other files touched.

## How verified

- `pros make` builds clean (PROS CLI 3.5.6), including `Compiled src/EZ-Template/drive/drive.cpp [OK]`.
- Confirmed `all_imus` and `good_imus` are populated together in every constructor (`std::deque<pros::Imu*>` in both cases), so `good_imus = all_imus` restores the full roster rather than emptying it.

## Hardware checklist

Single IMU: unplug it, boot, call chassis.drive_imu_scaler_set(1.0) from the auton — must print the calibration failure and not crash. Then with two IMUs, unplug the second, wait for 'port dropped', re-plug it, call chassis.drive_imu_calibrate() again — both must be in good_imus afterwards.

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: eebe62461c89a93ae39151c013766139f2b9c2d4 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34080524068)
- via manual download: [EZ-Template@4.0.0+eebe62.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003523314.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+eebe62.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003523314.zip;
pros c fetch EZ-Template@4.0.0+eebe62.zip;
pros c apply EZ-Template@4.0.0+eebe62;
rm EZ-Template@4.0.0+eebe62.zip;
```