### PR TITLE
Disable drive mode on competition state change

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3619,6 +3619,7 @@ class Drive {
   double turn_left(double target, double current, bool print = false);
   double turn_right(double target, double current, bool print = false);
   bool imu_calibration_complete = false;
+  uint8_t last_comp_status = 0;
 
   // IMU watchdog state: every IMU ever constructed (never shrinks), and
   // per-port health tracking used by check_imu_task() to eject/re-add IMUs.

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -25,6 +25,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_INTEGRATED;
+  last_comp_status = pros::competition::get_status();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -60,6 +61,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_INTEGRATED;
+  last_comp_status = pros::competition::get_status();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -106,6 +108,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_ADI_ENCODER;
+  last_comp_status = pros::competition::get_status();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -142,6 +145,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_ADI_ENCODER;
+  last_comp_status = pros::competition::get_status();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -178,6 +182,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(abs(right_rotation_port)),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_ROTATION;
+  last_comp_status = pros::competition::get_status();
   left_rotation.set_reversed(util::reversed_active(left_rotation_port));
   right_rotation.set_reversed(util::reversed_active(right_rotation_port));
 

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -21,6 +21,14 @@ void Drive::ez_auto_task() {
       // Run odom
       ez_tracking_task();
 
+      // Stop commanding the drive whenever the competition state changes (auton -> disabled ->
+      // driver) or while disabled, so a motion cut off by field control cannot resume on its own.
+      uint8_t comp_status = pros::competition::get_status();
+      if (pros::competition::is_disabled() || comp_status != last_comp_status) {
+        if (drive_mode_get() != DISABLE) drive_mode_set(DISABLE, false);
+      }
+      last_comp_status = comp_status;
+
       // Autonomous PID
       switch (drive_mode_get()) {
         case DRIVE:


### PR DESCRIPTION
## What was wrong

When autonomous ends, PROS kills the autonomous task, but `Drive::ez_auto_task()` in `src/EZ-Template/drive/pid_tasks.cpp` keeps running whatever `mode` was active with the last target still set. The robot is disabled between periods so nothing moves, but the moment driver control is enabled the task resumes driving toward the stale target until the first `drive_set()` call from the opcontrol loop. A team that does setup at the top of `opcontrol()` before their first drive call would see the robot drive off on its own.

## What the change does

- `src/EZ-Template/drive/pid_tasks.cpp`: inside the locked block of `ez_auto_task()`, before the `switch (drive_mode_get())`, the task now reads `pros::competition::get_status()` each loop. If the robot is currently disabled, or the competition status changed since the last loop (auton -> disabled, disabled -> driver, etc.), it forces `drive_mode_set(DISABLE, false)` so no motor command is sent (the `false` skips the stop-drive side effect). Odometry (`ez_tracking_task()`) and the IMU watchdog (`check_imu_task()`) keep running unaffected. `last_comp_status` is then updated every loop so the next iteration can detect the next transition.
- `include/EZ-Template/drive/drive.hpp`: added a private member `uint8_t last_comp_status = 0;` next to the other simple private state flags (near `imu_calibration_complete`).
- `src/EZ-Template/drive/drive.cpp`: seeded `last_comp_status = pros::competition::get_status();` in the body of **all five** `Drive::Drive(...)` constructor overloads, right after each one's `is_tracker = ...;` line. The class has five non-delegating constructors (integrated encoders, integrated encoders with redundant IMUs, tracking wheels on the brain, tracking wheels on a 3-wire expander, and rotation sensors) — none of them call another, so each needed its own copy of this line. This is a mechanical, faithful extension of the same fix to every overload, not scope creep: skipping any of them would leave that overload's users without a valid baseline on the very first task loop.

Outside of a connected competition switch, `pros::competition::get_status()` is constant and `pros::competition::is_disabled()` is false, so this guard never fires — bench testing, running auton from the brain menu, and skills challenges are unaffected.

## Verification

- `pros make` completed successfully (exit code 0). All source files compiled `[OK]`, including the three touched here (`drive.cpp`, `pid_tasks.cpp`) and the unmodified `main.cpp`/`autons.cpp`. The build log shows one unrelated, pre-existing, explicitly-ignored line (`mkdir: cannot create directory './bin': File exists` / `Error 1 (ignored)`) that make itself marks as ignored and does not affect the exit code or the resulting binaries.
- `git diff --stat` against `origin/dev` shows changes confined to exactly the three files described above, 14 insertions, 0 deletions, no reformatting.
- `#include "pros/misc.hpp"` was already present at the top of `pid_tasks.cpp` prior to this change — nothing new was added there.
- Note: `src/EZ-Template/drive/drive.cpp` does not include `pros/misc.hpp` directly (it includes `EZ-Template/api.hpp`, okapi headers, `pros/llemu.hpp`, `pros/screen.hpp`); `pros::competition::get_status()` resolves there through a transitive include. It compiles cleanly, so no change was made, just flagging it for awareness.

## Hardware checklist

Hardware checklist: with a competition switch, start an auton that drives 48 in, flip to disabled mid-motion, flip to driver control — the robot must not move until the driver touches a stick.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 516a5ffb698eba39775ab8c3bf0198e8bc570975 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34081998589)
- via manual download: [EZ-Template@4.0.0+761be7.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003973937.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+761be7.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003973937.zip;
pros c fetch EZ-Template@4.0.0+761be7.zip;
pros c apply EZ-Template@4.0.0+761be7;
rm EZ-Template@4.0.0+761be7.zip;
```