### PR TITLE
Fix auton selector append bug and unsafe SD-card reads (M10)

### DIFF
--- a/include/EZ-Template/auton_selector.hpp
+++ b/include/EZ-Template/auton_selector.hpp
@@ -22,6 +22,13 @@ class AutonSelector {
   AutonSelector(std::vector<Auton> autons);
   void selected_auton_call();
   void selected_auton_print();
+
+  /**
+   * Appends the given autons to the existing list of autons.
+   *
+   * \param autons
+   *        vector of Autons to append to the current list
+   */
   void autons_add(std::vector<Auton> autons);
 };
 }  // namespace ez

--- a/include/EZ-Template/sdcard.hpp
+++ b/include/EZ-Template/sdcard.hpp
@@ -58,6 +58,10 @@ extern pros::adi::DigitalIn* limit_switch_right;
 /**
  * Initialize two limit switches to change pages on the lcd.
  *
+ * The library never takes ownership of the pointers passed in and will not
+ * delete them, including when called with both pointers null to disable this
+ * feature.
+ *
  * @param left_limit_port
  *        port for the left limit switch
  * @param right_limit_port

--- a/src/EZ-Template/auton_selector.cpp
+++ b/src/EZ-Template/auton_selector.cpp
@@ -32,7 +32,7 @@ void ez::AutonSelector::selected_auton_call() {
 }
 
 void ez::AutonSelector::autons_add(std::vector<Auton> autons) {
-  auton_count += autons.size();
+  Autons.insert(Autons.end(), autons.begin(), autons.end());
+  auton_count = Autons.size();
   auton_page_current = 0;
-  Autons.assign(autons.begin(), autons.end());
 }

--- a/src/EZ-Template/drive/user_input.cpp
+++ b/src/EZ-Template/drive/user_input.cpp
@@ -4,6 +4,8 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+#include <cstdlib>
+
 #include "EZ-Template/PID.hpp"
 #include "EZ-Template/drive/drive.hpp"
 #include "pros/misc.h"
@@ -33,10 +35,15 @@ void Drive::opcontrol_curve_sd_initialize() {
   FILE* l_usd_file_read;
   // If file exists...
   if ((l_usd_file_read = fopen("/usd/left_curve.txt", "r"))) {
-    char l_buf[5];
-    fread(l_buf, 1, 5, l_usd_file_read);
-    left_curve_scale = std::stof(l_buf);
+    char buf[32] = {0};
+    fread(buf, 1, sizeof(buf) - 1, l_usd_file_read);
     fclose(l_usd_file_read);
+    char* end = nullptr;
+    double parsed = strtod(buf, &end);
+    if (end != buf)
+      left_curve_scale = parsed;
+    else
+      printf("EZ-Template: couldn't parse /usd/left_curve.txt, keeping current curve\n");
   }
   // If file doesn't exist, create file
   else {
@@ -47,10 +54,15 @@ void Drive::opcontrol_curve_sd_initialize() {
   FILE* r_usd_file_read;
   // If file exists...
   if ((r_usd_file_read = fopen("/usd/right_curve.txt", "r"))) {
-    char l_buf[5];
-    fread(l_buf, 1, 5, r_usd_file_read);
-    right_curve_scale = std::stof(l_buf);
+    char buf[32] = {0};
+    fread(buf, 1, sizeof(buf) - 1, r_usd_file_read);
     fclose(r_usd_file_read);
+    char* end = nullptr;
+    double parsed = strtod(buf, &end);
+    if (end != buf)
+      right_curve_scale = parsed;
+    else
+      printf("EZ-Template: couldn't parse /usd/right_curve.txt, keeping current curve\n");
   }
   // If file doesn't exist, create file
   else {

--- a/src/EZ-Template/sdcard.cpp
+++ b/src/EZ-Template/sdcard.cpp
@@ -6,6 +6,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "sdcard.hpp"
 
+#include <cstdlib>
 #include <filesystem>
 
 #include "auton_selector.hpp"
@@ -36,10 +37,15 @@ void auton_selector_initialize() {
   FILE* as_usd_file_read;
   // If file exists...
   if ((as_usd_file_read = fopen("/usd/auto.txt", "r"))) {
-    char a_buf[10];
-    fread(a_buf, 1, 10, as_usd_file_read);
-    ez::as::auton_selector.auton_page_current = std::stof(a_buf);
+    char buf[32] = {0};
+    fread(buf, 1, sizeof(buf) - 1, as_usd_file_read);
     fclose(as_usd_file_read);
+    char* end = nullptr;
+    double parsed = strtod(buf, &end);
+    if (end != buf)
+      ez::as::auton_selector.auton_page_current = parsed;
+    else
+      printf("EZ-Template: couldn't parse /usd/auto.txt, keeping current auton page\n");
   }
   // If file doesn't exist, create file
   else {
@@ -149,8 +155,6 @@ pros::adi::DigitalIn* limit_switch_right = nullptr;
 pros::Task limit_switch_task(ez::as::limitSwitchTask);
 void limit_switch_lcd_initialize(pros::adi::DigitalIn* right_limit, pros::adi::DigitalIn* left_limit) {
   if (!left_limit && !right_limit) {
-    delete limit_switch_left;
-    delete limit_switch_right;
     if (pros::millis() <= 100)
       turn_off = true;
     return;


### PR DESCRIPTION
Three independent fixes from the 4.0.0-beta.1 audit, ID M10.

## 1. AutonSelector::autons_add() silently discarded previously added autons

`autons_add()` called `Autons.assign(...)`, which replaces the vector's contents, while `auton_count` was incremented by the size of the new batch. A second call to `autons_add()` (or a call after `health::preflight_register()`) left `auton_count` larger than the actual vector, so paging through autons could index past the end of `Autons`.

Fixed by appending with `insert()` and recomputing `auton_count` from `Autons.size()` afterward, so the count always matches the vector's real contents. `auton_page_current` is still reset to 0 on each call, unchanged.

Also added a Doxygen comment above the `autons_add()` declaration in `include/EZ-Template/auton_selector.hpp`, since none existed. Note: this header currently has no Doxygen comments on any other declaration either, so this is a new addition, not an update to an existing one.

## 2. Unsafe fixed-buffer SD-card reads could throw uncaught or read garbage

`auton_selector_initialize()` (in `sdcard.cpp`) and both curve-read blocks in `Drive::opcontrol_curve_sd_initialize()` (in `drive/user_input.cpp`) read into small fixed-size buffers (10 and 5 bytes) with `fread` and passed them directly to `std::stof` with no guaranteed NUL termination. Since the writer always emits `std::to_string(double)`, which is at least 8 characters, the buffer was always completely filled by a normal write, leaving no terminator, and an empty or truncated file could make `std::stof` throw an uncaught exception straight out of `initialize()`, aborting the program.

All three read sites now use a zero-filled 32-byte buffer, `fread` sized to `sizeof(buf) - 1`, and `strtod` with an end-pointer check. On successful parse the value is used; on failure the current in-memory value is kept and one line is printed naming the specific file that failed to parse, instead of throwing. The existing range check on `auton_page_current` after the read in `auton_selector_initialize()` is unchanged.

`<cstdlib>` (for `strtod`) was added explicitly to both `sdcard.cpp` and `src/EZ-Template/drive/user_input.cpp`, since the latter also now calls `strtod` directly and didn't already include it. Transitive availability via PROS's `api.h` couldn't be verified since that header isn't vendored in this repo (it comes from the PROS kernel at build time), so it's included explicitly in both files to be safe.

## 3. limit_switch_lcd_initialize(nullptr, nullptr) deleted pointers the library never owned

Calling `limit_switch_lcd_initialize(nullptr, nullptr)` to disable the feature unconditionally called `delete` on `limit_switch_left` and `limit_switch_right`, even though those could be globals or stack objects a user passed in that the library never allocated.

Removed the two `delete` calls; the early-return/disable behavior is otherwise unchanged. Updated the Doxygen comment on the declaration in `include/EZ-Template/sdcard.hpp` to state that the library never takes ownership of the pointers passed in and will not delete them.

## Verification

- `pros make` builds clean (PROS CLI 3.5.6) — all five changed files compiled OK, cold/hot package linked successfully.
- Hardware checklist (SD-read fix): With an SD card, create an empty auto.txt and boot; the program must start and print the one-line message rather than aborting.

Scope: only the five files these fixes require — `src/EZ-Template/auton_selector.cpp`, `include/EZ-Template/auton_selector.hpp`, `src/EZ-Template/sdcard.cpp`, `include/EZ-Template/sdcard.hpp`, `src/EZ-Template/drive/user_input.cpp`. No reformatting or drive-by changes elsewhere.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 7961918576674bbb820f513f7cfcb2f52e8dc097 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34080593964)
- via manual download: [EZ-Template@4.0.0+796191.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003544949.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+796191.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003544949.zip;
pros c fetch EZ-Template@4.0.0+796191.zip;
pros c apply EZ-Template@4.0.0+796191;
rm EZ-Template@4.0.0+796191.zip;
```