### PR TITLE
Fix ptp boomerang misdetection and stale heading target after boomerang (M7)

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3609,7 +3609,7 @@ class Drive {
   void raw_pid_odom_pp_set(std::vector<odom> imovements, bool slew_on);
   bool ptf1_running = false;
   std::vector<pose> find_point_to_face(pose current, pose target, drive_directions dir, bool set_global);
-  void raw_pid_odom_ptp_set(odom imovement, bool slew_on);
+  void raw_pid_odom_ptp_set(odom imovement, bool slew_on, bool is_boomerang);
   std::vector<odom> inject_points(std::vector<odom> imovements);
   std::vector<pose> point_to_face = {{0, 0, 0}, {0, 0, 0}};
   double turn_is_toleranced(double target, double current, double input, double longest, double shortest);

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -155,6 +155,11 @@ void Drive::pid_wait() {
     if (xy_exit == mA_EXIT || xy_exit == VELOCITY_EXIT || a_exit == mA_EXIT || a_exit == VELOCITY_EXIT) {
       interfered = true;
     }
+
+    {
+      std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+      if (odom_target_start.theta != ANGLE_NOT_SET) headingPID.target_set(odom_target_start.theta);
+    }
   }
 
   // Turn Exit
@@ -438,9 +443,17 @@ void Drive::pid_wait_until_index(int index) {
 void Drive::pid_wait_quick() {
   if (mode == PURE_PURSUIT) {
     pid_wait_until_index(injected_pp_index.size() - 2);
+    {
+      std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+      if (odom_target_start.theta != ANGLE_NOT_SET) headingPID.target_set(odom_target_start.theta);
+    }
     return;
   } else if (mode == POINT_TO_POINT) {
     pid_wait_until_point(odom_target_start);
+    {
+      std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
+      if (odom_target_start.theta != ANGLE_NOT_SET) headingPID.target_set(odom_target_start.theta);
+    }
     return;
   } else if (mode == TURN || mode == SWING || mode == TURN_TO_POINT) {
     // chain_target_start is already internal-frame and already behavior-resolved

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -252,7 +252,7 @@ void Drive::boomerang_task() {
 
   if (odom_target.x != temp.x || odom_target.y != temp.y) {
     bool slew_on = slew_left.enabled() || slew_right.enabled() ? true : false;
-    raw_pid_odom_ptp_set({temp, pp_movements[target_index].drive_direction, pp_movements[target_index].max_xy_speed}, slew_on);
+    raw_pid_odom_ptp_set({temp, pp_movements[target_index].drive_direction, pp_movements[target_index].max_xy_speed}, slew_on, true);
   }
 
   // printf("cur(%.2f, %.2f, %.2f)   tar(%.2f, %.2f, %.2f)   h %.2f  \n", odom_x_get(), odom_y_get(), odom_theta_get(), temp.x, temp.y, temp.theta, h);
@@ -266,7 +266,7 @@ void Drive::pp_task() {
       pp_index = pp_index >= pp_movements.size() - 1 ? pp_index : pp_index + 1;
       bool slew_on = slew_left.enabled() || slew_right.enabled() ? true : false;
       if (!current_slew_on) slew_on = false;
-      raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on);
+      raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on, pp_movements[pp_index].target.theta != ANGLE_NOT_SET);
     }
   }
 

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -381,7 +381,7 @@ void Drive::pid_odom_ptp_set(odom imovement, bool slew_on) {
   current_slew_on = slew_on;
   slew_min_when_it_enabled = 0;
   slew_will_enable_later = false;
-  raw_pid_odom_ptp_set(imovement, slew_on);
+  raw_pid_odom_ptp_set(imovement, slew_on, false);
 
   // Initialize slew
   int dir = current_drive_direction == REV ? -1 : 1;  // If we're going backwards, add a -1
@@ -415,7 +415,7 @@ void Drive::raw_pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
   l_start = drive_sensor_left();
   r_start = drive_sensor_right();
 
-  raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on);
+  raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on, pp_movements[0].target.theta != ANGLE_NOT_SET);
 
   // Initialize slew
   int dir = current_drive_direction == REV ? -1 : 1;  // If we're going backwards, add a -1
@@ -429,7 +429,7 @@ void Drive::raw_pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
 /////
 // Base point to point
 /////
-void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on) {
+void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on, bool is_boomerang) {
   // Update current drive/turn behavior
   current_drive_direction = imovement.drive_direction;
 
@@ -496,9 +496,7 @@ void Drive::raw_pid_odom_ptp_set(odom imovement, bool slew_on) {
     slew_right.constants_set(slew_consts.distance_to_travel, slew_min);
   }
 
-  bool is_current_boomerang = false;
-  if (mode == PURE_PURSUIT)
-    is_current_boomerang = pp_movements[pp_index].target.theta != ANGLE_NOT_SET ? true : false;
+  bool is_current_boomerang = is_boomerang;
   if (print_toggle && !was_last_pp_mode_boomerang) {
     if (mode == PURE_PURSUIT)
       printf(" ");


### PR DESCRIPTION
## What was wrong

\`raw_pid_odom_ptp_set()\` in \`set_odom_pid.cpp\` decided whether the current segment was a boomerang by checking \`mode == PURE_PURSUIT && pp_movements[pp_index].target.theta != ANGLE_NOT_SET\`. Both of those are the PREVIOUS motion's values when called from \`pid_odom_ptp_set()\`, because \`mode\` is only updated at the end of that setter (via \`drive_mode_set(POINT_TO_POINT)\`, called after \`raw_pid_odom_ptp_set\`). So a plain point-to-point immediately after a path that ended on a boomerang would run with the boomerang angular PID constants instead of the normal odom angular constants.

Separately, after a boomerang finishes, the stored \`headingPID\` target is the angle toward the last carrot point (an approximation used to steer the tail end of the boomerang), not the theta the caller actually asked for. Any \`pid_drive_set\` or relative turn issued right after a boomerang would build on that approximate angle instead of the true final heading.

## What changed

1. Added an explicit \`bool is_boomerang\` parameter to \`raw_pid_odom_ptp_set(odom imovement, bool slew_on, bool is_boomerang)\` (updated in \`drive.hpp\`), and deleted the \`mode == PURE_PURSUIT\` inference inside the function body in favor of using the parameter directly. Each caller now passes its own known boomerang-ness:
   - \`pid_odom_ptp_set(odom, bool)\`: \`false\`
   - \`raw_pid_odom_pp_set(...)\`: \`pp_movements[0].target.theta != ANGLE_NOT_SET\`
   - \`pp_task()\`'s advance-to-next-point call: \`pp_movements[pp_index].target.theta != ANGLE_NOT_SET\`
   - \`boomerang_task()\`: \`true\`

   \`was_last_pp_mode_boomerang\` and the print gating around it are unchanged.

2. In \`pid_wait()\` (the \`POINT_TO_POINT || PURE_PURSUIT\` branch) and \`pid_wait_quick()\` (both the \`PURE_PURSUIT\` and \`POINT_TO_POINT\` early-return paths), after the wait loop finishes and before returning, added under \`drive_mutex\`:
   \`if (odom_target_start.theta != ANGLE_NOT_SET) headingPID.target_set(odom_target_start.theta);\`
   \`odom_target_start.theta\` is already in the internal frame (it went through \`flip_pose\`) and is the robot's actual final heading for both forward and reverse boomerangs, so no direction adjustment is needed.

## How verified

- \`pros make\` builds clean.
- Reasoned through the two scenarios from the audit:
  - A pure-pursuit path ending on a boomerang, followed by a plain point-to-point: with the old code, the new ptp's first \`raw_pid_odom_ptp_set\` call would see stale \`mode == PURE_PURSUIT\` (not yet reset) and stale \`pp_movements[pp_index].target.theta\` from the finished path, misclassifying the new ptp as a boomerang. With the fix, \`pid_odom_ptp_set\` explicitly passes \`false\`, so the new motion always uses \`odom_angularPID\` constants, never \`boomerangPID\`.
  - A boomerang to (0, 24, 45) followed by \`pid_drive_set\`: \`odom_target_start.theta\` was set to 45 (in internal frame) when the boomerang started, is untouched by the boomerang's carrot-following logic, and is now written into \`headingPID\`'s target at the end of \`pid_wait()\`/\`pid_wait_quick()\`, so the heading target is exactly 45 before the next motion reads it.

Audit ID: M7
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: c2c68d81155299f0b726bfef5df995934691039c -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34080680016)
- via manual download: [EZ-Template@4.0.0+c2c68d.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003572633.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+c2c68d.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10003572633.zip;
pros c fetch EZ-Template@4.0.0+c2c68d.zip;
pros c apply EZ-Template@4.0.0+c2c68d;
rm EZ-Template@4.0.0+c2c68d.zip;
```