### PR TITLE
🐛 Fix first-motion cancel on entering autonomous

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -3622,7 +3622,7 @@ class Drive {
   double turn_left(double target, double current, bool print = false);
   double turn_right(double target, double current, bool print = false);
   bool imu_calibration_complete = false;
-  uint8_t last_comp_status = 0;
+  bool last_was_autonomous = false;
   int loading_bar_last_x = 0;
 
   // IMU watchdog state: every IMU ever constructed (never shrinks), and

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -25,7 +25,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_INTEGRATED;
-  last_comp_status = pros::competition::get_status();
+  last_was_autonomous = pros::competition::is_autonomous();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -61,7 +61,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_INTEGRATED;
-  last_comp_status = pros::competition::get_status();
+  last_was_autonomous = pros::competition::is_autonomous();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -108,7 +108,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_ADI_ENCODER;
-  last_comp_status = pros::competition::get_status();
+  last_was_autonomous = pros::competition::is_autonomous();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -145,7 +145,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(-1),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_ADI_ENCODER;
-  last_comp_status = pros::competition::get_status();
+  last_was_autonomous = pros::competition::is_autonomous();
 
   // Set ports to a global vector
   for (auto i : left_motor_ports) {
@@ -182,7 +182,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
       right_rotation(abs(right_rotation_port)),
       ez_auto([this] { this->ez_auto_task(); }) {
   is_tracker = DRIVE_ROTATION;
-  last_comp_status = pros::competition::get_status();
+  last_was_autonomous = pros::competition::is_autonomous();
   left_rotation.set_reversed(util::reversed_active(left_rotation_port));
   right_rotation.set_reversed(util::reversed_active(right_rotation_port));
 

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -21,13 +21,15 @@ void Drive::ez_auto_task() {
       // Run odom
       ez_tracking_task();
 
-      // Stop commanding the drive whenever the competition state changes (auton -> disabled ->
-      // driver) or while disabled, so a motion cut off by field control cannot resume on its own.
-      uint8_t comp_status = pros::competition::get_status();
-      if (pros::competition::is_disabled() || comp_status != last_comp_status) {
+      // Stop commanding the drive while disabled, and once when autonomous ends, so a motion
+      // that field control cut off cannot resume on its own when driver control starts.
+      // Entering autonomous must NOT trigger this: the autonomous task's first setter can run
+      // before this pass sees the status change, and disabling here would cancel that motion.
+      bool autonomous_now = pros::competition::is_autonomous();
+      if (pros::competition::is_disabled() || (last_was_autonomous && !autonomous_now)) {
         if (drive_mode_get() != DISABLE) drive_mode_set(DISABLE, false);
       }
-      last_comp_status = comp_status;
+      last_was_autonomous = autonomous_now;
 
       // Autonomous PID
       switch (drive_mode_get()) {


### PR DESCRIPTION
## What was wrong

PR #365 added this to `ez_auto_task()` in `src/EZ-Template/drive/pid_tasks.cpp`:

```cpp
uint8_t comp_status = pros::competition::get_status();
if (pros::competition::is_disabled() || comp_status != last_comp_status) {
  if (drive_mode_get() != DISABLE) drive_mode_set(DISABLE, false);
}
last_comp_status = comp_status;
```

The intent was to stop a motion that field control cut off from resuming when driver
control starts. But `comp_status != last_comp_status` is also true on the transition
INTO autonomous (the DISABLED bit clears). PROS's system daemon polls competition
status every 2 ms and starts the autonomous task immediately; `ez_auto` polls every
10 ms. When the autonomous task reaches its first `pid_*_set` before `ez_auto`'s next
pass, which is most of that 10 ms window, the pass then sets `mode = DISABLE`,
`pid_wait()` matches no mode and returns at once, and the auton's first motion is
skipped. Running an auton from opcontrol (the template's B+DOWN) cannot reproduce it
because the status never changes there.

## The fix

Trigger only while disabled, or on LEAVING autonomous. Never on entering it.

```cpp
bool autonomous_now = pros::competition::is_autonomous();
if (pros::competition::is_disabled() || (last_was_autonomous && !autonomous_now)) {
  if (drive_mode_get() != DISABLE) drive_mode_set(DISABLE, false);
}
last_was_autonomous = autonomous_now;
```

- `include/EZ-Template/drive/drive.hpp`: `uint8_t last_comp_status = 0;` ->
  `bool last_was_autonomous = false;`.
- `src/EZ-Template/drive/drive.cpp`: each of the five constructor lines
  `last_comp_status = pros::competition::get_status();` ->
  `last_was_autonomous = pros::competition::is_autonomous();`.

Nothing else changes. The `is_disabled()` half already covers auton -> disabled ->
driver, and the "leaving autonomous" half covers a competition switch flipped
straight from auton to driver while enabled.

Note that PROS reports `is_autonomous()` true during the disabled period before
autonomous too (the mode bit is set while disabled), so `last_was_autonomous` is
already true when autonomous is enabled and the transition does not fire. Please
don't "simplify" this back to a raw status comparison — that's exactly what
reintroduces the bug.

## Verification

`pros make` is clean.

Sequence walkthrough, `mode` at each step:

1. Field: disabled(auton) -> autonomous -> disabled -> driver. `DISABLE` fires during
   both disabled periods only; the auton's first setter is never cancelled (entering
   autonomous does not trigger, since `last_was_autonomous` is already `true`).
2. Competition switch: autonomous -> driver with no disabled gap. One `DISABLE` fires
   on that falling edge of `is_autonomous()`.
3. No field control, auton run from opcontrol via B+DOWN. Competition status never
   changes, so this never triggers.
4. Boot while connected and disabled. `DISABLE` fires (mode is already `DISABLE`),
   harmless.

## Hardware checklist

Requires a V5 competition switch or a field controller. Not yet run — needs Jess.
Adding checks 1 and 2 below to the beta 2 hardware checklist as permanent items;
this class of bug is invisible without field control.

1. Load `drive_example` (drive 24 in, back 12, back 12). Switch to autonomous ten
   times from disabled. The robot must drive forward first on all ten runs. On
   current `dev`, expect most runs to skip the forward leg and begin by reversing.
2. Start the auton, flip to disabled mid-motion, flip to driver. Robot must stay
   still until a stick moves.
3. Flip autonomous straight to driver while enabled, mid-motion. Same.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 4d0b00a84e58d7b1b28762846ab3a76fdb35d9c4 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34083196127)
- via manual download: [EZ-Template@4.0.0+4d0b00.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10004335637.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+4d0b00.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10004335637.zip;
pros c fetch EZ-Template@4.0.0+4d0b00.zip;
pros c apply EZ-Template@4.0.0+4d0b00;
rm EZ-Template@4.0.0+4d0b00.zip;
```