### PR TITLE
🐛 Enable -Wall -Wextra, fix library warnings, add warnings-clean CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,21 @@ jobs:
         with:
           name: ${{ steps.test.outputs.name }}
           path: ${{ github.workspace }}/template/*
+
+  warnings-clean:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Builds only the library archive (excludes src/main.cpp and src/autons.cpp,
+      # which are user project files this repo happens to keep around for local dev
+      # and aren't held to this warning bar) with -Werror on top of the Makefile's
+      # WARNFLAGS. Reuses the same pinned pros-build image as the job above so the
+      # compiler is identical, but overrides its entrypoint to run `make` directly
+      # instead of the image's default full-project build script.
+      - name: Build library with -Werror
+        uses: docker://ghcr.io/lemlib/pros-build:v5.1.0
+        with:
+          entrypoint: bash
+          args: -c "make library EXTRA_CXXFLAGS='-Wno-deprecated-enum-enum-conversion -Werror'"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BINDIR=$(ROOT)/bin
 SRCDIR=$(ROOT)/src
 INCDIR=$(ROOT)/include
 
-WARNFLAGS+=
+WARNFLAGS+=-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
 EXTRA_CFLAGS=
 EXTRA_CXXFLAGS=-Wno-deprecated-enum-enum-conversion
 

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -80,7 +80,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   good_imus.push_back(imu);
   all_imus.push_back(imu);
   imu_scale_values.push_back(1);
-  for (int i = 1; i < imu_ports.size(); i++) {
+  for (std::size_t i = 1; i < imu_ports.size(); i++) {
     pros::Imu* temp = new pros::Imu(imu_ports[i]);
     good_imus.push_back(temp);
     all_imus.push_back(temp);
@@ -211,16 +211,23 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
 }
 
 Drive::~Drive() {
+  // pros::v5::Imu has virtual member functions but a non-virtual destructor.
+  // Every pointer in all_imus was allocated as exactly `new pros::Imu(...)`
+  // (never a derived type), so this delete is safe; the diagnostic can't be
+  // fixed at the source since pros::Imu is a vendored header.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
   for (pros::Imu* n : all_imus) {
     delete n;
   }
+#pragma GCC diagnostic pop
   good_imus.clear();
   all_imus.clear();
 }
 
 // set defaults
 void Drive::drive_defaults_set() {
-  for (int i = 0; i < good_imus.size(); i++) {
+  for (std::size_t i = 0; i < good_imus.size(); i++) {
     good_imus[i]->set_data_rate(5);
   }
 
@@ -419,7 +426,7 @@ bool Drive::drive_current_left_over() { return left_motors.front().is_over_curre
 void Drive::drive_imu_reset(double new_heading) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  for (int i = 0; i < all_imus.size(); i++) {
+  for (std::size_t i = 0; i < all_imus.size(); i++) {
     // Reads go through get_this_imu(), which multiplies by the scaler, so the
     // value written here has to be divided by it to read back as new_heading
     auto scaler = imu_scale_map.find(all_imus[i]->get_port());
@@ -469,7 +476,7 @@ double Drive::drive_imu_scaler_get() {
 void Drive::drive_imus_scalers_set(std::vector<double> scales) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  for (int i = 0; i < std::min(all_imus.size(), scales.size()); i++) {
+  for (std::size_t i = 0; i < std::min(all_imus.size(), scales.size()); i++) {
     imu_scale_map[all_imus[i]->get_port()] = scales[i];
   }
 }
@@ -521,7 +528,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
 
   // No IMUs are calibrated yet, set them all to false
   std::map<int, bool> imus_status, imus_done, imus_last_status;
-  for (int i = 0; i < good_imus.size(); i++) {
+  for (std::size_t i = 0; i < good_imus.size(); i++) {
     good_imus[i]->reset();
     int port = good_imus[i]->get_port();
     imus_status[port] = good_imus[i]->is_calibrating();
@@ -538,7 +545,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
 
     if (!successful) {
       // Check if each IMU is done calibrating
-      for (int i = 0; i < good_imus.size(); i++) {
+      for (std::size_t i = 0; i < good_imus.size(); i++) {
         int port = good_imus[i]->get_port();
         imus_last_status[port] = imus_status[port];
         imus_status[port] = good_imus[i]->is_calibrating();
@@ -549,7 +556,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
 
     // Check if all IMUs have calibrated
     successful = true;
-    for (int i = 0; i < good_imus.size(); i++) {
+    for (std::size_t i = 0; i < good_imus.size(); i++) {
       if (!imus_done[good_imus[i]->get_port()]) {
         successful = false;
       } else {
@@ -567,7 +574,7 @@ bool Drive::drive_imu_calibrate(bool run_loading_animation) {
           printf("No IMU plugged in");
         } else {
           printf("Only IMUs in ports {");
-          for (int i = 0; i < good_imus.size(); i++) {
+          for (std::size_t i = 0; i < good_imus.size(); i++) {
             int port = good_imus[i]->get_port();
             if (imus_done[port])
               printf(" %i", port);

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -127,7 +127,7 @@ void Drive::pid_wait() {
 
     // Wait until pure pursuit is on the last point, then continue as normal
     if (mode == PURE_PURSUIT) {
-      while (pp_index != pp_movements.size() - 1) {
+      while (pp_index != (int)pp_movements.size() - 1) {
         xyPID.velocity_sensor_secondary_set(drive_imu_accel_get());
         current_a_odomPID.velocity_sensor_secondary_set(drive_imu_accel_get());
         xy_exit = xy_exit != RUNNING ? xy_exit : xyPID.exit_condition({left_motors[0], right_motors[0]});

--- a/src/EZ-Template/drive/pid_tasks.cpp
+++ b/src/EZ-Template/drive/pid_tasks.cpp
@@ -273,8 +273,8 @@ void Drive::boomerang_task() {
 
 void Drive::pp_task() {
   if (fabs(util::distance_to_point(pp_movements[pp_index].target, odom_pose_get())) < odom_look_ahead_get()) {
-    if (pp_index < pp_movements.size() - 1) {
-      pp_index = pp_index >= pp_movements.size() - 1 ? pp_index : pp_index + 1;
+    if (pp_index < (int)pp_movements.size() - 1) {
+      pp_index = pp_index >= (int)pp_movements.size() - 1 ? pp_index : pp_index + 1;
       bool slew_on = slew_left.enabled() || slew_right.enabled() ? true : false;
       if (!current_slew_on) slew_on = false;
       raw_pid_odom_ptp_set(pp_movements[pp_index], slew_on, pp_movements[pp_index].target.theta != ANGLE_NOT_SET);

--- a/src/EZ-Template/drive/pid_tuner.cpp
+++ b/src/EZ-Template/drive/pid_tuner.cpp
@@ -118,7 +118,7 @@ void Drive::pid_tuner_print() {
   if (!pid_tuner_on) return;
 
   // Ensure that the user column is within the size of the pid tuner
-  if (column > used_pid_tuner_pids->size() - 1)
+  if (column > (int)used_pid_tuner_pids->size() - 1)
     column = 0;
 
   double kp = used_pid_tuner_pids->at(column).consts->kp;
@@ -209,7 +209,7 @@ void Drive::pid_tuner_iterate() {
   // Up / Down for Rows
   if (master.get_digital_new_press(pid_tuner_pageRight)) {
     column++;
-    if (column > used_pid_tuner_pids->size() - 1)
+    if (column > (int)used_pid_tuner_pids->size() - 1)
       column = 0;
     pid_tuner_print();
   } else if (master.get_digital_new_press(pid_tuner_pageLeft)) {

--- a/src/EZ-Template/drive/purepursuit_math.cpp
+++ b/src/EZ-Template/drive/purepursuit_math.cpp
@@ -26,7 +26,6 @@ double Drive::is_past_target(pose target, pose current) {
   double fake_angle = util::to_rad((util::absolute_angle_to_point(ptf, {fakek_x, fakek_y})) + add);
 
   // Rotate around origin
-  double fake_x = (fakek_x * cos(fake_angle)) - (fakek_y * sin(fake_angle));
   double fake_y = (fakek_y * cos(fake_angle)) + (fakek_x * sin(fake_angle));
 
   return fake_y;
@@ -90,7 +89,7 @@ std::vector<odom> Drive::inject_points(std::vector<ez::odom> imovements) {
 
   // Inject new parent points for boomerang
   int t = 0;
-  for (int i = 0; i < input.size() - 1; i++) {
+  for (std::size_t i = 0; i < input.size() - 1; i++) {
     int j = i + t;
     j = i;
     if (input[j].target.theta != ANGLE_NOT_SET) {
@@ -107,7 +106,7 @@ std::vector<odom> Drive::inject_points(std::vector<ez::odom> imovements) {
   }
 
   // Shift all the turn behaviors 1 parent point down
-  for (int i = 0; i < input.size() - 1; i++) {
+  for (std::size_t i = 0; i < input.size() - 1; i++) {
     input[i].turn_behavior = input[i + 1].turn_behavior;
   }
   input.back().turn_behavior = raw;
@@ -119,7 +118,7 @@ std::vector<odom> Drive::inject_points(std::vector<ez::odom> imovements) {
   bool allow_injecting = false;  // Flag to disable injecting for the first few points
 
   // This for loop runs for how many points there are minus one because there is one less vector then points
-  for (int i = 0; i < input.size() - 1; i++) {
+  for (std::size_t i = 0; i < input.size() - 1; i++) {
     // Figure out how many points fit in the vector
     int num_of_points_that_fit = (util::distance_to_point(input[i + 1].target, input[i].target)) / SPACING;
 
@@ -190,7 +189,7 @@ std::vector<odom> Drive::smooth_path(std::vector<odom> ipath, double weight_smoo
   bool boomerang_after_not_done = false;
 
   // Convert odom to array
-  for (int i = 0; i < ipath.size(); i++) {
+  for (std::size_t i = 0; i < ipath.size(); i++) {
     path[i][0] = new_path[i][0] = ipath[i].target.x;
     path[i][1] = new_path[i][1] = ipath[i].target.y;
     path[i][2] = new_path[i][2] = ipath[i].target.theta;
@@ -229,7 +228,7 @@ std::vector<odom> Drive::smooth_path(std::vector<odom> ipath, double weight_smoo
 
   while (change >= tolerance) {
     change = 0.0;
-    for (int i = 1; i < ipath.size() - 2; i++) {
+    for (std::size_t i = 1; i < ipath.size() - 2; i++) {
       // if (path[i][2] == ANGLE_NOT_SET) {
       if (!dont_touch[i]) {
         for (int j = 0; j < 2; j++) {
@@ -251,7 +250,7 @@ std::vector<odom> Drive::smooth_path(std::vector<odom> ipath, double weight_smoo
   // Convert array to odom
   std::vector<odom> output = ipath;  // Set output to input so target angles, turn types and speed hold
   // Overwrite x and y
-  for (int i = 0; i < ipath.size(); i++) {
+  for (std::size_t i = 0; i < ipath.size(); i++) {
     output[i].target.x = new_path[i][0];
     output[i].target.y = new_path[i][1];
   }
@@ -292,7 +291,6 @@ double Drive::turn_is_toleranced(double target, double current, double input, do
     return output;
 
   int long_error_sgn = util::sgn(long_error);
-  int short_error_sgn = util::sgn(short_error);
 
   if (turn_biased_left)
     output = long_error_sgn == -1 ? longest : shortest;

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -12,7 +12,7 @@ namespace ez {
 // Set constants
 /////
 void Drive::odom_path_print() {
-  for (int i = 0; i < pp_movements.size(); i++) {
+  for (int i = 0; i < (int)pp_movements.size(); i++) {
     printf("Point %i: (%.2f, %.2f, %.2f)\n", i, pp_movements[i].target.x, pp_movements[i].target.y, pp_movements[i].target.theta);
   }
 }
@@ -22,7 +22,6 @@ ez::e_angle_behavior Drive::pid_odom_behavior_get() { return default_odom_type; 
 pose Drive::flip_pose(pose input) {
   int flip_x = x_flipped ? -1 : 1;
   int flip_y = y_flipped ? -1 : 1;
-  int flip_a = theta_flipped ? -1 : 1;
 
   pose new_pose = input;
   new_pose.x *= flip_x;
@@ -35,7 +34,7 @@ pose Drive::flip_pose(pose input) {
 std::vector<odom> Drive::set_odoms_direction(std::vector<odom> inputs) {
   std::vector<odom> output;
 
-  for (int i = 0; i < inputs.size(); i++) {
+  for (std::size_t i = 0; i < inputs.size(); i++) {
     pose new_pose = flip_pose(inputs[i].target);
     output.push_back({new_pose,
                       inputs[i].drive_direction,
@@ -363,7 +362,7 @@ void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
   input.insert(input.begin(), {{{odom_x_get(), odom_y_get(), ANGLE_NOT_SET}, imovements[0].drive_direction, imovements[0].max_xy_speed}});
 
   int t = 0;
-  for (int i = 0; i < input.size() - 1; i++) {
+  for (std::size_t i = 0; i < input.size() - 1; i++) {
     // Inject new parent points for boomerang
     int j = i + t;
     j = i;
@@ -381,7 +380,7 @@ void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
   }
 
   // Shift all the turn behaviors 1 parent point down
-  for (int i = 0; i < input.size() - 1; i++) {
+  for (std::size_t i = 0; i < input.size() - 1; i++) {
     input[i].turn_behavior = input[i + 1].turn_behavior;
   }
   input.back().turn_behavior = raw;
@@ -389,7 +388,7 @@ void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
   // This is used for pid_wait_until_pp()
   injected_pp_index.clear();
   injected_pp_index.push_back(0);
-  for (int i = 0; i < input.size(); i++) {
+  for (std::size_t i = 0; i < input.size(); i++) {
     if (i != 0 && input[i - 1].target.theta == ANGLE_NOT_SET)
       injected_pp_index.push_back(i);
   }

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -205,7 +205,6 @@ void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_s
 }
 void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int opposite_speed, e_angle_behavior behavior) {
   double target = p_target.convert(okapi::degree);  // Convert okapi unit to degree
-  bool slew_on = is_swing_slew_enabled(type, target, drive_angle_get());
   pid_swing_set(type, target, speed, opposite_speed, behavior);
 }
 // Relative

--- a/src/EZ-Template/drive/user_input.cpp
+++ b/src/EZ-Template/drive/user_input.cpp
@@ -314,9 +314,6 @@ void Drive::opcontrol_tank() {
   // Toggle for controller curve
   opcontrol_curve_buttons_iterate();
 
-  auto analog_left_value = master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y);
-  auto analog_right_value = master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_Y);
-
   // Put the joysticks through the curve function
   int l_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y)));
   int r_stick = opcontrol_curve_left(clipped_joystick(master.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_Y)));

--- a/src/EZ-Template/util.cpp
+++ b/src/EZ-Template/util.cpp
@@ -43,7 +43,7 @@ std::string get_last_word(std::string text) {
 }
 std::string get_rest_of_the_word(std::string text, int position) {
   std::string word = "";
-  for (int i = position; i < text.length(); i++) {
+  for (int i = position; i < (int)text.length(); i++) {
     if (text[i] != ' ' && text[i] != '\n') {
       word += text[i];
     } else {
@@ -58,7 +58,7 @@ void screen_print(std::string text, int line) {
   std::vector<string> texts = {};
   std::string temp = "";
 
-  for (int i = 0; i < text.length(); i++) {
+  for (int i = 0; i < (int)text.length(); i++) {
     if (text[i] != '\n' && temp.length() + 1 > 38) {
       auto last_word = get_last_word(temp);
       if (last_word == temp) {
@@ -73,13 +73,13 @@ void screen_print(std::string text, int line) {
         last_word += rest_of_word;
         i += rest_of_word.length();
         temp = last_word;
-        if (i >= text.length() - 1) {
+        if (i >= (int)text.length() - 1) {
           texts.push_back(temp);
           break;
         }
       }
     }
-    if (i >= text.length() - 1) {
+    if (i >= (int)text.length() - 1) {
       temp += text[i];
       texts.push_back(temp);
       temp = "";
@@ -270,7 +270,7 @@ pose united_pose_to_pose(united_pose input) {
 
 std::vector<odom> united_odoms_to_odoms(std::vector<united_odom> inputs) {
   std::vector<odom> output;
-  for (int i = 0; i < inputs.size(); i++) {
+  for (std::size_t i = 0; i < inputs.size(); i++) {
     pose new_pose = united_pose_to_pose(inputs[i].target);
     output.push_back({{new_pose}, inputs[i].drive_direction, inputs[i].max_xy_speed, inputs[i].turn_behavior});
   }


### PR DESCRIPTION
## What changed

Sets `WARNFLAGS+=-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers` in the Makefile (it was empty — the library has never been compiled with warnings on) and fixes every one of the 36 warnings that came out of it in `src/EZ-Template/` and `include/EZ-Template/`. Adds a `warnings-clean` CI job that rebuilds the library with `-Werror` so this doesn't regress.

## Why

The library builds silently through real bugs (sign-compare mismatches, unused variables that turned out to be leftover from refactors) because nothing has ever surfaced them. `-Werror` in CI catches new ones going forward without breaking anyone's local build over a compiler version difference (kept out of the Makefile itself, only added in CI via `EXTRA_CXXFLAGS`).

## Warnings fixed (36)

**Sign-compare, `int` vs `.size()`** — loop variable changed to `std::size_t` where it's never used signed elsewhere in the function:
- `drive.cpp`: constructor loop over `imu_ports` (L83), `drive_defaults_set`/`good_imus` (L223), `drive_imu_reset`/`all_imus` (L422), `drive_imus_scalers_set`/`std::min(...)` (L472), `drive_imu_calibrate`/`good_imus` (L524, L541, L552, L570)
- `purepursuit_math.cpp`: `inject_points` boomerang-injection and turn-behavior-shift loops (L93, L110), the point-injection loop (L122), `smooth_path`'s array-convert/smooth/write-back loops (L193, L232, L254)
- `set_odom_pid.cpp`: `set_odoms_direction` (L38), `pid_odom_pp_set`'s two loops (L366, L384)
- `util.cpp`: `united_odoms_to_odoms` (L273)

Where the index is *also* compared elsewhere in the same function (against 0, or via `printf %i`), the `.size()` side is cast to `int` at the comparison site instead of changing the variable's type — matching the cast-to-int convention this codebase already uses for `pp_index`:
- `exit_conditions.cpp` L130, `pid_tasks.cpp` L276-277 (both index into `pp_movements`, `pp_index` stays `int`)
- `pid_tuner.cpp` L121, L212 (`column` is compared `< 0` a few lines below)
- `set_odom_pid.cpp` L15 (`printf("%i", i, ...)`)
- `util.cpp` L46, L61, L76, L82 (`get_rest_of_the_word`/`screen_print`)

**Unused variables removed** (each confirmed to be a pure, side-effect-free read with no other reference — deleting them cannot change behavior):
- `purepursuit_math.cpp` L29 `fake_x` — half of a rotation-around-origin pair where only the `y` component (`fake_y`) is ever returned
- `purepursuit_math.cpp` L295 `short_error_sgn` — computed via `util::sgn`, never read
- `set_odom_pid.cpp` L25 `flip_a` — theta flipping is handled by `flip_angle_target` instead
- `set_swing_pid.cpp` L208 `slew_on` (QAngle overload of `pid_swing_set`) — the overload calls into the 5-arg `pid_swing_set`, which recomputes the identical value itself; removing the unused local also drops one redundant `is_swing_slew_enabled` call
- `user_input.cpp` L317-318 `analog_left_value`/`analog_right_value` — read via `master.get_analog(...)` and never referenced; `opcontrol_tank` re-reads both sticks a few lines later instead

**delete-non-virtual-dtor**, `drive.cpp` `Drive::~Drive()`: `pros::v5::Imu` has virtual member functions but a non-virtual destructor. Every pointer in `all_imus` is allocated as exactly `new pros::Imu(...)` (never a derived type) so the delete is safe, but `pros::Imu` is a vendored header (`include/pros`) so the destructor can't be fixed at the source. Suppressed locally with a scoped `#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"` around just that loop, with a comment explaining why, rather than a project-wide `-Wno-` flag.

## Didn't match the prompt / audit

- **No vendored-header warnings appeared** (`include/pros`, `include/okapi`, `include/liblvgl`) under the new flags, so the `-isystem` reclassification (to make sure `include/EZ-Template` still warns via `-iquote` while vendored headers don't) wasn't needed. Not added, since it'd be untested scaffolding for a problem that doesn't currently exist.
- **The `int j = i + t; j = i;` dead-store pattern** (`purepursuit_math.cpp` L94-95, `set_odom_pid.cpp` L368-369) flagged by cppcheck in the earlier audit does **not** produce a GCC warning under `-Wall -Wextra` — `j` is read after the reassignment, so `-Wunused-but-set-variable` doesn't fire. Left untouched: removing the discarded `i + t` computation would be a behavior change (does `t`'s boomerang-offset math matter here or not?), not a warning fix, and belongs in a separate change with its own reasoning, not bundled into this one.
- **`src/main.cpp` still has one warning** (`ez_motor_temperatures`, sign-compare on `chassis.left_motors.size()`) — out of scope since this repo's local rules keep `src/main.cpp` as-is. This is exactly why the CI job below builds only the library, not the whole project.

## `warnings-clean` CI job

Runs `make library EXTRA_CXXFLAGS='-Wno-deprecated-enum-enum-conversion -Werror'` — `make library` is a target the Makefile already exposes (`$(LIBAR)`, i.e. just `EZ-Template.a`) that only compiles `src/EZ-Template/`, deliberately skipping `src/main.cpp`/`src/autons.cpp` since those aren't part of the published library and `main.cpp`'s pre-existing warning above would otherwise fail a whole-project `-Werror` build.

The existing `build` job uses `LemLib/pros-build@v5.1.0`, but that action's `action.yml` takes no input for extra build flags or a custom make target — it always runs its own bundled full-project build script. So this job instead runs the identical pinned image directly (`docker://ghcr.io/lemlib/pros-build:v5.1.0`) with an overridden `entrypoint`/`args` to run the `make` invocation above. Same toolchain either way (verified the image's Dockerfile: `arm-gnu-toolchain 14.3.1`, matching the version installed locally via `pros make`), just without going through the action's default build script.

## Verified

- `pros make` (full project) builds with zero warnings from `src/EZ-Template/` and `include/EZ-Template/` — confirmed on a clean rebuild.
- `pros make library EXTRA_CXXFLAGS='-Wno-deprecated-enum-enum-conversion -Werror'` (the exact CI job command) builds all 21 library source files and links `EZ-Template.a` cleanly, exit 0.
- The full project (`pros make`, default target) still links `bin/hot.package.bin`/`bin/cold.package.elf` successfully with the new `WARNFLAGS`.

## For the maintainer

Once this merges, please mark `warnings-clean` (added here) as a required check in branch protection for `dev` and `main` alongside the existing `build` job.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 792335db5108a70c820b9d3ad1887315942b7e05 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34087182673)
- via manual download: [EZ-Template@4.0.0+792335.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10005579187.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+792335.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10005579187.zip;
pros c fetch EZ-Template@4.0.0+792335.zip;
pros c apply EZ-Template@4.0.0+792335;
rm EZ-Template@4.0.0+792335.zip;
```