### PR TITLE
🐛 Remove using-namespace-std, cache tick-per-inch, tag encoder units

### DIFF
--- a/include/EZ-Template/auton_selector.hpp
+++ b/include/EZ-Template/auton_selector.hpp
@@ -9,8 +9,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EZ-Template/auton.hpp"
 
-using namespace std;
-
 namespace ez {
 class AutonSelector {
  public:

--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -2086,7 +2086,7 @@ class Drive {
   void pid_turn_set(okapi::QAngle p_target, int speed, e_angle_behavior behavior, bool slew_on);
 
   /**
-   * Sets the robot to turn relative to current heading using PID with okapi units, only using slew if globally enabled.
+   * Sets the robot to turn relative to the last commanded heading target using PID with okapi units, only using slew if globally enabled. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value in okapi angle units
@@ -2096,7 +2096,7 @@ class Drive {
   void pid_turn_relative_set(okapi::QAngle p_target, int speed);
 
   /**
-   * Sets the robot to turn relative to current heading using PID with okapi units, only using slew if globally enabled.
+   * Sets the robot to turn relative to the last commanded heading target using PID with okapi units, only using slew if globally enabled. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value in okapi angle units
@@ -2108,7 +2108,7 @@ class Drive {
   void pid_turn_relative_set(okapi::QAngle p_target, int speed, e_angle_behavior behavior);
 
   /**
-   * Sets the robot to turn relative to current heading using PID with okapi units, using slew if enabled for this motion.
+   * Sets the robot to turn relative to the last commanded heading target using PID with okapi units, using slew if enabled for this motion. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value in okapi angle units
@@ -2120,7 +2120,7 @@ class Drive {
   void pid_turn_relative_set(okapi::QAngle p_target, int speed, bool slew_on);
 
   /**
-   * Sets the robot to turn relative to current heading using PID with okapi units, using slew if enabled for this motion.
+   * Sets the robot to turn relative to the last commanded heading target using PID with okapi units, using slew if enabled for this motion. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value in okapi angle units
@@ -2134,7 +2134,7 @@ class Drive {
   void pid_turn_relative_set(okapi::QAngle p_target, int speed, e_angle_behavior behavior, bool slew_on);
 
   /**
-   * Sets the robot to turn relative to current heading using PID without okapi units, only using slew if globally enabled.
+   * Sets the robot to turn relative to the last commanded heading target using PID without okapi units, only using slew if globally enabled. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value as a double, unit is degrees
@@ -2144,7 +2144,7 @@ class Drive {
   void pid_turn_relative_set(double target, int speed);
 
   /**
-   * Sets the robot to turn relative to current heading using PID without okapi units, only using slew if globally enabled.
+   * Sets the robot to turn relative to the last commanded heading target using PID without okapi units, only using slew if globally enabled. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value as a double, unit is degrees
@@ -2156,7 +2156,7 @@ class Drive {
   void pid_turn_relative_set(double target, int speed, e_angle_behavior behavior);
 
   /**
-   * Sets the robot to turn relative to current heading using PID without okapi units, using slew if enabled for this motion.
+   * Sets the robot to turn relative to the last commanded heading target using PID without okapi units, using slew if enabled for this motion. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value as a double, unit is degrees
@@ -2168,7 +2168,7 @@ class Drive {
   void pid_turn_relative_set(double target, int speed, bool slew_on);
 
   /**
-   * Sets the robot to turn relative to current heading using PID without okapi units, using slew if enabled for this motion.
+   * Sets the robot to turn relative to the last commanded heading target using PID without okapi units, using slew if enabled for this motion. Adds to the last target rather than the current heading, so error doesn't accumulate across chained relative turns.
    *
    * \param p_target
    *        target value as a double, unit is degrees
@@ -3791,6 +3791,15 @@ class Drive {
   double TICK_PER_REV;
   double TICK_PER_INCH;
   double CIRCUMFERENCE;
+
+  /**
+   * Recomputes TICK_PER_REV/CIRCUMFERENCE/TICK_PER_INCH from WHEEL_DIAMETER,
+   * CARTRIDGE, RATIO and is_tracker. Called from every constructor and from
+   * drive_ratio_set()/drive_rpm_set(), the only places those inputs change;
+   * drive_tick_per_inch() just returns the cached TICK_PER_INCH so it's
+   * cheap to call from drive_sensor_left()/_right() every sensor read.
+   */
+  void drive_tick_per_inch_compute();
 
   double CARTRIDGE;
   double RATIO;

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -31,11 +31,13 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   for (auto i : left_motor_ports) {
     pros::Motor temp((std::int8_t)abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     left_motors.push_back(temp);
   }
   for (auto i : right_motor_ports) {
     pros::Motor temp((std::int8_t)abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     right_motors.push_back(temp);
   }
 
@@ -46,7 +48,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
   CARTRIDGE = ticks;
-  TICK_PER_INCH = drive_tick_per_inch();
+  drive_tick_per_inch_compute();
 
   drive_defaults_set();
 }
@@ -67,11 +69,13 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   for (auto i : left_motor_ports) {
     pros::Motor temp((std::int8_t)abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     left_motors.push_back(temp);
   }
   for (auto i : right_motor_ports) {
     pros::Motor temp((std::int8_t)abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     right_motors.push_back(temp);
   }
 
@@ -92,7 +96,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
   CARTRIDGE = ticks;
-  TICK_PER_INCH = drive_tick_per_inch();
+  drive_tick_per_inch_compute();
 
   drive_defaults_set();
 }
@@ -114,11 +118,13 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   for (auto i : left_motor_ports) {
     pros::Motor temp(abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     left_motors.push_back(temp);
   }
   for (auto i : right_motor_ports) {
     pros::Motor temp(abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     right_motors.push_back(temp);
   }
 
@@ -129,7 +135,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
   CARTRIDGE = ticks;
-  TICK_PER_INCH = drive_tick_per_inch();
+  drive_tick_per_inch_compute();
 
   drive_defaults_set();
 }
@@ -151,11 +157,13 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   for (auto i : left_motor_ports) {
     pros::Motor temp(abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     left_motors.push_back(temp);
   }
   for (auto i : right_motor_ports) {
     pros::Motor temp(abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     right_motors.push_back(temp);
   }
 
@@ -166,7 +174,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
   CARTRIDGE = ticks;
-  TICK_PER_INCH = drive_tick_per_inch();
+  drive_tick_per_inch_compute();
 
   drive_defaults_set();
 }
@@ -190,11 +198,13 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   for (auto i : left_motor_ports) {
     pros::Motor temp(abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     left_motors.push_back(temp);
   }
   for (auto i : right_motor_ports) {
     pros::Motor temp(abs(i));
     temp.set_reversed(util::reversed_active(i));
+    temp.set_encoder_units(pros::MotorUnits::counts);  // drive_tick_per_inch() assumes counts
     right_motors.push_back(temp);
   }
 
@@ -205,7 +215,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
   CARTRIDGE = 36000;
-  TICK_PER_INCH = drive_tick_per_inch();
+  drive_tick_per_inch_compute();
 
   drive_defaults_set();
 }
@@ -305,6 +315,10 @@ double Drive::drive_tick_per_inch() {
   if (is_tracker == ODOM_TRACKER)
     return odom_tracker_right->ticks_per_inch();
 
+  return TICK_PER_INCH;
+}
+
+void Drive::drive_tick_per_inch_compute() {
   CIRCUMFERENCE = WHEEL_DIAMETER * M_PI;
 
   if (is_tracker == DRIVE_ADI_ENCODER || is_tracker == DRIVE_ROTATION)
@@ -313,12 +327,17 @@ double Drive::drive_tick_per_inch() {
     TICK_PER_REV = (50.0 * (3600.0 / CARTRIDGE)) * RATIO;  // with no cart, the encoder reads 50 counts per rotation
 
   TICK_PER_INCH = (TICK_PER_REV / CIRCUMFERENCE);
-  return TICK_PER_INCH;
 }
 
-void Drive::drive_ratio_set(double ratio) { RATIO = ratio; }
+void Drive::drive_ratio_set(double ratio) {
+  RATIO = ratio;
+  drive_tick_per_inch_compute();
+}
 double Drive::drive_ratio_get() { return RATIO; }
-void Drive::drive_rpm_set(double rpm) { CARTRIDGE = rpm; }
+void Drive::drive_rpm_set(double rpm) {
+  CARTRIDGE = rpm;
+  drive_tick_per_inch_compute();
+}
 double Drive::drive_rpm_get() { return CARTRIDGE; }
 
 void Drive::private_drive_set(int left, int right) {

--- a/src/EZ-Template/util.cpp
+++ b/src/EZ-Template/util.cpp
@@ -55,7 +55,7 @@ std::string get_rest_of_the_word(std::string text, int position) {
 
 void screen_print(std::string text, int line) {
   int CurrAutoLine = line;
-  std::vector<string> texts = {};
+  std::vector<std::string> texts = {};
   std::string temp = "";
 
   for (int i = 0; i < (int)text.length(); i++) {

--- a/test/stub/pros/motors.h
+++ b/test/stub/pros/motors.h
@@ -10,4 +10,11 @@ enum motor_brake_mode_e_t {
   E_MOTOR_BRAKE_HOLD = 2,
 };
 
+enum class MotorEncoderUnits {
+  degrees = 0,
+  rotations = 1,
+  counts = 2,
+};
+using MotorUnits = MotorEncoderUnits;
+
 }  // namespace pros

--- a/test/stub/pros/motors.hpp
+++ b/test/stub/pros/motors.hpp
@@ -63,6 +63,7 @@ class Motor {
     return 1;
   }
   std::int32_t set_current_limit(std::int32_t limit) { return 1; }
+  std::int32_t set_encoder_units(MotorUnits units) { return 1; }
   std::int32_t set_brake_mode(motor_brake_mode_e_t mode) {
     fake().brake_mode = mode;
     return 1;


### PR DESCRIPTION
## Stacking

Based on `test/host-unit-tests` (#373), which is itself based on `build/warnings` (#370) — neither has merged yet, so this diff includes both of their commits until they do. Base this PR against `test/host-unit-tests` for review; retarget to `dev` once the chain merges.

## What changed

**`using namespace std;` removed from `auton_selector.hpp`.** Safe now that #333 qualified every `abs()` call on a `double` — confirmed here by grep: every remaining unqualified `abs()` in the codebase takes an `int` (motor ports, mA limits, joystick values), which resolves to the global C `abs(int)` regardless of this using-directive. One place *was* relying on it transitively, caught by a full rebuild after removing the line: `util.cpp`'s `screen_print()` declared `std::vector<string> texts` with a bare `string`. Qualified to `std::string`.

> **Breaking:** user code that relied on `std` being visible through EZ-Template's headers (bare `string`, `vector`, etc. after including `api.hpp`) will need its own `std::` prefix or using-directive. Belongs in the 4.0 changelog.

**`set_encoder_units(pros::MotorUnits::counts)` added to every `Drive` constructor**, right after each `pros::Motor` is constructed (10 call sites across the 5 constructors), with a comment that `drive_tick_per_inch()` assumes counts (300/900/1800 per output revolution depending on cartridge).

**`drive_tick_per_inch()` no longer recomputes on every call.** It was rebuilding `TICK_PER_REV`/`CIRCUMFERENCE`/`TICK_PER_INCH` from scratch every time it ran — including from `drive_sensor_left()`/`drive_sensor_right()`, called on every PID pass. Split the actual computation into a new private `drive_tick_per_inch_compute()`, called once from every constructor and from `drive_ratio_set()`/`drive_rpm_set()` — the only places `WHEEL_DIAMETER`/`CARTRIDGE`/`RATIO` change. `drive_tick_per_inch()` itself is now just a getter: returns the cached `TICK_PER_INCH`, or for `ODOM_TRACKER` mode still delegates live to the tracker's own `ticks_per_inch()` (untouched — that one's cheap enough on its own and the prompt this cleanup batch came from only asked for the Drive-level caching).

**`pid_turn_relative_set()`'s Doxygen fixed on all 8 overloads.** It said "relative to current heading," but the code (`heading_target_user_frame() + target`) adds to the *last commanded heading target*, not the current sensor reading — on purpose, so error doesn't accumulate across chained relative turns. Reworded to say that.

## Verification

- `pros make` clean under Branch 1's `-Wall -Wextra` flags — only the pre-existing, out-of-scope `src/main.cpp` warning appears (same as on `build/warnings`; untouched here).
- `make -C test` passes: 29 cases, 147 assertions, same count as #373 — extended the host stub's `pros::Motor` (`test/stub/pros/motors.hpp`, `motors.h`) with `set_encoder_units()`/`pros::MotorUnits` so the test binary keeps building against the new constructor calls.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 786153a5d6eed51851abcda7cc6341eb5c5c2f9b -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34094990961)
- via manual download: [EZ-Template@4.0.0+786153.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10008200090.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+786153.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10008200090.zip;
pros c fetch EZ-Template@4.0.0+786153.zip;
pros c apply EZ-Template@4.0.0+786153;
rm EZ-Template@4.0.0+786153.zip;
```