### PR TITLE
Drop internal audit-ID tags from test names/comments

### DIFF
--- a/test/test_pid.cpp
+++ b/test/test_pid.cpp
@@ -1,19 +1,19 @@
-// PID [H1]: with small 1 in / 90 ms and big 3 in / 250 ms, an error held at
-// 2 in returns BIG_EXIT after 26 passes and never SMALL_EXIT; an error held
-// at 0.5 in returns SMALL_EXIT after 10 passes.
-// PID [H2]: with ki set, integral accumulates while error keeps sign and
+// Exit conditions: with small 1 in / 90 ms and big 3 in / 250 ms, an error
+// held at 2 in returns BIG_EXIT after 26 passes and never SMALL_EXIT; an
+// error held at 0.5 in returns SMALL_EXIT after 10 passes.
+// Integral: with ki set, integral accumulates while error keeps sign and
 // resets when error sign flips; a position sign flip with constant error
 // sign does NOT reset it; motion_reset(c) zeroes the integral and makes the
 // next derivative 0.
-// PID [M15]: exit_condition(pros::MotorGroup) produces BIG_EXIT at the same
-// pass count as the plain overload.
+// MotorGroup overload: exit_condition(pros::MotorGroup) produces BIG_EXIT at
+// the same pass count as the plain overload.
 #include "doctest.h"
 
 #include "EZ-Template/api.hpp"
 
 using namespace ez;
 
-TEST_CASE("PID [H1] BIG_EXIT after 26 passes at a held 2in error, never SMALL_EXIT") {
+TEST_CASE("PID BIG_EXIT after 26 passes at a held 2in error, never SMALL_EXIT") {
   PID pid;
   pid.exit_condition_set(90, 1.0, 250, 3.0);
   pid.error = 2.0;  // within big_error (3), outside small_error (1)
@@ -25,7 +25,7 @@ TEST_CASE("PID [H1] BIG_EXIT after 26 passes at a held 2in error, never SMALL_EX
   CHECK(pid.exit_condition() == BIG_EXIT);
 }
 
-TEST_CASE("PID [H1] SMALL_EXIT after 10 passes at a held 0.5in error") {
+TEST_CASE("PID SMALL_EXIT after 10 passes at a held 0.5in error") {
   PID pid;
   pid.exit_condition_set(90, 1.0, 250, 3.0);
   pid.error = 0.5;  // within both small_error (1) and big_error (3)
@@ -37,12 +37,12 @@ TEST_CASE("PID [H1] SMALL_EXIT after 10 passes at a held 0.5in error") {
   CHECK(pid.exit_condition() == SMALL_EXIT);
 }
 
-TEST_CASE("PID [M15] exit_condition(MotorGroup) matches the plain overload's pass count") {
+TEST_CASE("PID exit_condition(MotorGroup) matches the plain overload's pass count") {
   // mA_timeout is left at 0 (unset), so the MotorGroup-specific mA check
   // is skipped entirely and this falls straight through to the same
-  // exit_condition(print) as the H1 case above -- so it should take the
-  // same 26 passes to BIG_EXIT, not the ~20 the prompt that produced this
-  // suite estimated (see PR body).
+  // exit_condition(print) as the BIG_EXIT case above -- so it should take
+  // the same 26 passes to BIG_EXIT, not the ~20 passes a naive estimate
+  // (ignoring the mA-timeout skip) might suggest.
   PID pid;
   pid.exit_condition_set(90, 1.0, 250, 3.0);
   pid.error = 2.0;
@@ -55,7 +55,7 @@ TEST_CASE("PID [M15] exit_condition(MotorGroup) matches the plain overload's pas
   CHECK(pid.exit_condition(mg) == BIG_EXIT);
 }
 
-TEST_CASE("PID [H2] integral accumulates while error keeps sign, resets on sign flip") {
+TEST_CASE("PID integral accumulates while error keeps sign, resets on sign flip") {
   PID pid(1.0, 1.0, 0.0, 1000.0);  // start_i huge: integral always active
   pid.target_set(10);
 
@@ -75,7 +75,7 @@ TEST_CASE("PID [H2] integral accumulates while error keeps sign, resets on sign 
   CHECK(pid.integral == doctest::Approx(0));
 }
 
-TEST_CASE("PID [H2] a position sign flip with constant error sign does not reset integral") {
+TEST_CASE("PID a position sign flip with constant error sign does not reset integral") {
   PID pid(1.0, 1.0, 0.0, 1000.0);
   pid.target_set(100);  // far away: error stays positive even as current crosses 0
 
@@ -89,7 +89,7 @@ TEST_CASE("PID [H2] a position sign flip with constant error sign does not reset
   CHECK(pid.integral == doctest::Approx(200));
 }
 
-TEST_CASE("PID [H2] motion_reset zeroes the integral and primes the next derivative to 0") {
+TEST_CASE("PID motion_reset zeroes the integral and primes the next derivative to 0") {
   PID pid(1.0, 1.0, 0.0, 1000.0);
   pid.target_set(10);
   pid.compute(0);

--- a/test/test_purepursuit.cpp
+++ b/test/test_purepursuit.cpp
@@ -1,9 +1,9 @@
-// pure pursuit [H8, L10]: inject_points on a 24 in straight path at 0.5 in
-// spacing yields the expected count and injected_pp_index of size 2;
-// smooth_path on a 600-point path returns 600 points with endpoints
-// unchanged (this would have overflowed the old arrays);
-// new_turn_target_compute table for raw/cw/ccw/shortest/longest from current
-// 10 to targets 200, -160, 350, 0.
+// inject_points on a 24 in straight path at 0.5 in spacing yields the
+// expected count and injected_pp_index of size 2; smooth_path on a
+// 600-point path returns 600 points with endpoints unchanged (this would
+// have overflowed the old fixed-size arrays); new_turn_target_compute table
+// for raw/cw/ccw/shortest/longest from current 10 to targets 200, -160,
+// 350, 0.
 #include "doctest.h"
 
 #include "drive_test_access.hpp"
@@ -17,7 +17,7 @@ Drive make_chassis() {
 }
 }  // namespace
 
-TEST_CASE("pure pursuit [H8, L10] inject_points on a 24in straight path at 0.5in spacing") {
+TEST_CASE("pure pursuit inject_points on a 24in straight path at 0.5in spacing") {
   Drive chassis = make_chassis();
   chassis.odom_xyt_set(0.0, 0.0, 0.0);
 
@@ -32,7 +32,7 @@ TEST_CASE("pure pursuit [H8, L10] inject_points on a 24in straight path at 0.5in
   CHECK(DriveTestAccess::injected_pp_index(chassis).size() == 2);
 }
 
-TEST_CASE("pure pursuit [L10] smooth_path on a 600-point path returns 600 points with endpoints unchanged") {
+TEST_CASE("pure pursuit smooth_path on a 600-point path returns 600 points with endpoints unchanged") {
   Drive chassis = make_chassis();
 
   std::vector<odom> path;
@@ -50,7 +50,7 @@ TEST_CASE("pure pursuit [L10] smooth_path on a 600-point path returns 600 points
   CHECK(output.back().target.y == doctest::Approx(path.back().target.y));
 }
 
-TEST_CASE("pure pursuit [L10] new_turn_target_compute from current 10") {
+TEST_CASE("pure pursuit new_turn_target_compute from current 10") {
   Drive chassis = make_chassis();
   const double current = 10;
 

--- a/test/test_slew.cpp
+++ b/test/test_slew.cpp
@@ -1,4 +1,4 @@
-// slew [H9]: forward slew 3 in / min 70 / max 127: outputs at sensor 0, 1, 2
+// Forward slew ramp, 3 in / min 70 / max 127: outputs at sensor 0, 1, 2
 // are 70, 89, 108; at -5 the output is still >= 70 (clamped); initialize
 // with target == current leaves the slew disabled and output at max.
 #include "doctest.h"
@@ -7,7 +7,7 @@
 
 using namespace ez;
 
-TEST_CASE("slew [H9] ramps 70, 89, 108 over sensor 0, 1, 2") {
+TEST_CASE("slew ramps 70, 89, 108 over sensor 0, 1, 2") {
   slew s(3.0, 70);
   s.initialize(true, 127, 100, 0);  // enabled, max 127, target 100, current 0
 
@@ -16,14 +16,14 @@ TEST_CASE("slew [H9] ramps 70, 89, 108 over sensor 0, 1, 2") {
   CHECK(s.iterate(2) == doctest::Approx(108));
 }
 
-TEST_CASE("slew [H9] output stays clamped to min_speed behind the start") {
+TEST_CASE("slew output stays clamped to min_speed behind the start") {
   slew s(3.0, 70);
   s.initialize(true, 127, 100, 0);
 
   CHECK(s.iterate(-5) == doctest::Approx(70));
 }
 
-TEST_CASE("slew [H9] initialize with target == current disables slew and outputs max") {
+TEST_CASE("slew initialize with target == current disables slew and outputs max") {
   slew s(3.0, 70);
   s.initialize(true, 127, 50, 50);  // target == current
 

--- a/test/test_tracking.cpp
+++ b/test/test_tracking.cpp
@@ -1,13 +1,13 @@
-// tracking [H4, M3]: construct a Drive with fake IMEs and one fake left
-// tracker (3.5 in offset) and a fake back tracker (2.0 in); mark calibration
+// Tracking: construct a Drive with fake IMEs and one fake left tracker
+// (3.5 in offset) and a fake back tracker (2.0 in); mark calibration
 // complete; call odom_xyt_set(0, 0, 90); run ez_tracking_task() once with no
 // sensor change; assert x and y are within 1e-6 of 0. Then set odom
 // disabled, advance the fake wheels 100 in, enable, run one pass, assert
 // pose unchanged.
-// competition [#365 fix]: with the fake status moving disabled ->
-// autonomous, running the task body once after a pid_drive_set leaves
-// mode == DRIVE; moving autonomous -> driver with no disabled gap sets
-// mode == DISABLE once.
+// Competition state (regression coverage for GitHub issue #365): with the
+// fake status moving disabled -> autonomous, running the task body once
+// after a pid_drive_set leaves mode == DRIVE; moving autonomous -> driver
+// with no disabled gap sets mode == DISABLE once.
 #include "doctest.h"
 
 #include "drive_test_access.hpp"
@@ -34,7 +34,7 @@ void run_one_auto_task_pass(Drive& chassis) {
 }
 }  // namespace
 
-TEST_CASE("tracking [H4] no sensor change after priming leaves x/y at 0") {
+TEST_CASE("tracking no sensor change after priming leaves x/y at 0") {
   Drive chassis = make_chassis();
 
   tracking_wheel left_tracker(1, 3.25, 3.5);
@@ -58,7 +58,7 @@ TEST_CASE("tracking [H4] no sensor change after priming leaves x/y at 0") {
   CHECK(chassis.odom_y_get() == doctest::Approx(0.0).epsilon(1e-6));
 }
 
-TEST_CASE("tracking [M3] disabling odom before a sensor jump prevents that jump from ever showing up") {
+TEST_CASE("tracking disabling odom before a sensor jump prevents that jump from ever showing up") {
   Drive chassis = make_chassis();
 
   tracking_wheel left_tracker(1, 3.25, 3.5);
@@ -93,7 +93,7 @@ TEST_CASE("tracking [M3] disabling odom before a sensor jump prevents that jump 
   CHECK(chassis.odom_y_get() == doctest::Approx(y_before).epsilon(1e-6));
 }
 
-TEST_CASE("competition [#365 fix] disabled -> autonomous does not cancel the first motion") {
+TEST_CASE("competition state (#365) disabled -> autonomous does not cancel the first motion") {
   Drive chassis = make_chassis();
 
   test_stub::g_competition.disabled = true;
@@ -114,7 +114,7 @@ TEST_CASE("competition [#365 fix] disabled -> autonomous does not cancel the fir
   CHECK(chassis.drive_mode_get() == DRIVE);
 }
 
-TEST_CASE("competition [#365 fix] autonomous -> driver with no disabled gap forces DISABLE") {
+TEST_CASE("competition state (#365) autonomous -> driver with no disabled gap forces DISABLE") {
   Drive chassis = make_chassis();
 
   test_stub::g_competition.disabled = false;

--- a/test/test_turns.cpp
+++ b/test/test_turns.cpp
@@ -1,9 +1,9 @@
-// turns [H5, H6, M4]: with odom_theta_flip(true), pid_turn_set(90) then
-// pid_turn_relative_set(45) leaves headingPID.target_get() at -135;
-// pid_turn_set({24,24}, fwd) with x and theta flipped leaves it at -45;
-// pid_swing_set(LEFT_SWING, 90, 110, 45) mirrored selects the forward slew
-// constants; the turn-min gate does not engage for an 88 -> 90 turn and does
-// engage inside start_i for a 0 -> 90 turn.
+// With odom_theta_flip(true), pid_turn_set(90) then pid_turn_relative_set(45)
+// leaves headingPID.target_get() at -135; pid_turn_set({24,24}, fwd) with x
+// and theta flipped leaves it at -45; pid_swing_set(LEFT_SWING, 90, 110, 45)
+// mirrored selects the forward slew constants; the turn-min gate does not
+// engage for an 88 -> 90 turn and does engage inside start_i for a 0 -> 90
+// turn.
 #include "doctest.h"
 
 #include "drive_test_access.hpp"
@@ -17,7 +17,7 @@ Drive make_chassis() {
 }
 }  // namespace
 
-TEST_CASE("turns [H5] pid_turn_set then pid_turn_relative_set with theta flipped") {
+TEST_CASE("turns pid_turn_set then pid_turn_relative_set with theta flipped") {
   Drive chassis = make_chassis();
   chassis.odom_theta_flip(true);
 
@@ -27,7 +27,7 @@ TEST_CASE("turns [H5] pid_turn_set then pid_turn_relative_set with theta flipped
   CHECK(chassis.headingPID.target_get() == doctest::Approx(-135));
 }
 
-TEST_CASE("turns [H6] pid_turn_set(pose) with x and theta flipped") {
+TEST_CASE("turns pid_turn_set(pose) with x and theta flipped") {
   Drive chassis = make_chassis();
   chassis.odom_x_flip(true);
   chassis.odom_theta_flip(true);
@@ -40,7 +40,7 @@ TEST_CASE("turns [H6] pid_turn_set(pose) with x and theta flipped") {
   CHECK(chassis.headingPID.target_get() == doctest::Approx(-45));
 }
 
-TEST_CASE("turns [M4] mirrored LEFT_SWING selects the forward slew constants") {
+TEST_CASE("turns mirrored LEFT_SWING selects the forward slew constants") {
   Drive chassis = make_chassis();
   chassis.odom_theta_flip(true);  // mirrors LEFT_SWING <-> RIGHT_SWING
 
@@ -59,7 +59,7 @@ TEST_CASE("turns [M4] mirrored LEFT_SWING selects the forward slew constants") {
   CHECK(chassis.slew_swing.constants_get().min_speed == doctest::Approx(70));
 }
 
-TEST_CASE("turns [M4] turn-min gate does not engage for an 88 -> 90 turn") {
+TEST_CASE("turns turn-min gate does not engage for an 88 -> 90 turn") {
   Drive chassis = make_chassis();
   chassis.pid_turn_constants_set(20.0, 0.5, 0.0, 5.0);  // start_i = 5
   chassis.pid_turn_min_set(20);
@@ -77,7 +77,7 @@ TEST_CASE("turns [M4] turn-min gate does not engage for an 88 -> 90 turn") {
   CHECK(gyro_out == doctest::Approx(40).epsilon(0.01));
 }
 
-TEST_CASE("turns [M4] turn-min gate engages inside start_i for a 0 -> 90 turn") {
+TEST_CASE("turns turn-min gate engages inside start_i for a 0 -> 90 turn") {
   Drive chassis = make_chassis();
   chassis.pid_turn_constants_set(20.0, 0.5, 0.0, 5.0);  // start_i = 5
   chassis.pid_turn_min_set(20);


### PR DESCRIPTION
## What changed

Removes the `[H1]`/`[H2]`/`[M15]`/`[L10]`/etc. tags from the test names and header comments added in #373. Those referenced an external audit's numbering scheme that isn't part of this repo — clear right now, but meaningless to anyone (including us) once that context is gone.

Expanded the surrounding comments so each test explains what it's checking without needing the tag. Left the GitHub issue references (`#365`, `#369`) alone — those are real, permanently lookupable identifiers, not internal shorthand.

Comment/test-name only, no logic changes: 29 cases, 147 assertions still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: bc942cb15b6790409a8d760402c96b569b6d6577 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34096955172)
- via manual download: [EZ-Template@4.0.0+f081a8.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10008941228.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+f081a8.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10008941228.zip;
pros c fetch EZ-Template@4.0.0+f081a8.zip;
pros c apply EZ-Template@4.0.0+f081a8;
rm EZ-Template@4.0.0+f081a8.zip;
```