### PR TITLE
Make IMU scaling take a physical-turn reading instead of a raw multiplier

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -1444,17 +1444,19 @@ class Drive {
   double drive_imu_accel_get();
 
   /**
-   * Sets a new imu scaling factor.
+   * Calibrates the imu's scale using a physical turn.
    *
-   * This value is multiplied by the imu to change its output.
+   * Physically turn the robot 3600 degrees (10 full rotations) and pass in
+   * what the imu reported for that turn.  Internally, this is used to divide
+   * the imu's raw reading so it reports the true 3600.
    *
-   * \param scaler
-   *        factor to scale the imu by
+   * \param imu_value_after_3600
+   *        what the imu reads after physically turning the robot 3600 degrees
    */
-  void drive_imu_scaler_set(double scaler);
+  void drive_imu_scaler_set(double imu_value_after_3600);
 
   /**
-   * Returns the current imu scaling factor.
+   * Returns the imu value after a 3600 degree turn that produces the imu's current scale.
    */
   double drive_imu_scaler_get();
 
@@ -1462,17 +1464,18 @@ class Drive {
   std::map<int, std::pair<double, int>> prev_imu_values;
 
   /*
-   * Sets a new IMU scaling factor for all IMUs.
+   * Calibrates the scale of all IMUs using a physical turn.
    *
-   * This value is multiplied by the imu to change its output.
+   * Physically turn the robot 3600 degrees (10 full rotations) and pass in
+   * what each imu reported for that turn.
    *
-   * \param scales
-   *        input {0.99, 1.01...}
+   * \param imu_values_after_3600
+   *        what each imu reads after physically turning the robot 3600 degrees, input {3550, 3625...}
    */
-  void drive_imus_scalers_set(std::vector<double> scales);
+  void drive_imus_scalers_set(std::vector<double> imu_values_after_3600);
 
   /*
-   * Returns the scaling factor for all IMUs.
+   * Returns the imu value after a 3600 degree turn that produces each imu's current scale.
    */
   std::map<int, double> drive_imus_scalers_get();
 

--- a/src/EZ-Template/drive/drive.cpp
+++ b/src/EZ-Template/drive/drive.cpp
@@ -43,7 +43,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
 
   good_imus.push_back(imu);
   all_imus.push_back(imu);
-  drive_imu_scaler_set(1);
+  imu_scale_map[imu->get_port()] = 1.0;
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
@@ -80,17 +80,15 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
   }
 
   // Set all IMUs
-  std::vector<double> imu_scale_values = {};
   good_imus.push_back(imu);
   all_imus.push_back(imu);
-  imu_scale_values.push_back(1);
+  imu_scale_map[imu->get_port()] = 1.0;
   for (std::size_t i = 1; i < imu_ports.size(); i++) {
     pros::Imu* temp = new pros::Imu(imu_ports[i]);
     good_imus.push_back(temp);
     all_imus.push_back(temp);
-    imu_scale_values.push_back(1);
+    imu_scale_map[temp->get_port()] = 1.0;
   }
-  drive_imus_scalers_set(imu_scale_values);
 
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
@@ -130,7 +128,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
 
   good_imus.push_back(imu);
   all_imus.push_back(imu);
-  drive_imu_scaler_set(1);
+  imu_scale_map[imu->get_port()] = 1.0;
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
@@ -169,7 +167,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
 
   good_imus.push_back(imu);
   all_imus.push_back(imu);
-  drive_imu_scaler_set(1);
+  imu_scale_map[imu->get_port()] = 1.0;
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
@@ -210,7 +208,7 @@ Drive::Drive(std::vector<int> left_motor_ports, std::vector<int> right_motor_por
 
   good_imus.push_back(imu);
   all_imus.push_back(imu);
-  drive_imu_scaler_set(1);
+  imu_scale_map[imu->get_port()] = 1.0;
   // Set constants for tick_per_inch calculation
   WHEEL_DIAMETER = wheel_diameter;
   RATIO = ratio;
@@ -475,31 +473,48 @@ double Drive::drive_imu_accel_get() {
   return std::hypot(accel.x, accel.y);
 }
 
-void Drive::drive_imu_scaler_set(double scaler) {
+void Drive::drive_imu_scaler_set(double imu_value_after_3600) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
-  if (imu == nullptr) {
-    if (all_imus.empty()) return;
-    imu_scale_map[all_imus.front()->get_port()] = scaler;
+  if (imu_value_after_3600 == 0.0) {
+    printf("EZ-Template: drive_imu_scaler_set rejected 0, value must be the imu's reading after physically turning the robot 3600 degrees\n");
     return;
   }
-  imu_scale_map[imu->get_port()] = scaler;
+  double multiplier = 3600.0 / imu_value_after_3600;
+  if (imu == nullptr) {
+    if (all_imus.empty()) return;
+    imu_scale_map[all_imus.front()->get_port()] = multiplier;
+    return;
+  }
+  imu_scale_map[imu->get_port()] = multiplier;
 }
 double Drive::drive_imu_scaler_get() {
+  double multiplier = 1.0;
   if (imu == nullptr) {
-    if (all_imus.empty()) return 1.0;
-    return imu_scale_map[all_imus.front()->get_port()];
+    if (!all_imus.empty()) multiplier = imu_scale_map[all_imus.front()->get_port()];
+  } else {
+    multiplier = imu_scale_map[imu->get_port()];
   }
-  return imu_scale_map[imu->get_port()];
+  return multiplier != 0.0 ? 3600.0 / multiplier : 0.0;
 }
 
-void Drive::drive_imus_scalers_set(std::vector<double> scales) {
+void Drive::drive_imus_scalers_set(std::vector<double> imu_values_after_3600) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  for (std::size_t i = 0; i < std::min(all_imus.size(), scales.size()); i++) {
-    imu_scale_map[all_imus[i]->get_port()] = scales[i];
+  for (std::size_t i = 0; i < std::min(all_imus.size(), imu_values_after_3600.size()); i++) {
+    if (imu_values_after_3600[i] == 0.0) {
+      printf("EZ-Template: drive_imus_scalers_set rejected 0 for imu on port %i, value must be the imu's reading after physically turning the robot 3600 degrees\n", all_imus[i]->get_port());
+      continue;
+    }
+    imu_scale_map[all_imus[i]->get_port()] = 3600.0 / imu_values_after_3600[i];
   }
 }
-std::map<int, double> Drive::drive_imus_scalers_get() { return imu_scale_map; }
+std::map<int, double> Drive::drive_imus_scalers_get() {
+  std::map<int, double> output;
+  for (auto const& pair : imu_scale_map) {
+    output[pair.first] = pair.second != 0.0 ? 3600.0 / pair.second : 0.0;
+  }
+  return output;
+}
 
 void Drive::drive_imu_display_loading(int iter) {
   // If the lcd is already initialized, don't run this function

--- a/test/drive_test_access.hpp
+++ b/test/drive_test_access.hpp
@@ -36,6 +36,8 @@ struct DriveTestAccess {
     return d.is_swing_slew_enabled(type, target, current);
   }
   static e_swing swing_type_internal(Drive& d, e_swing type) { return d.swing_type_internal(type); }
+
+  static double get_this_imu(Drive& d, pros::Imu* imu) { return d.get_this_imu(imu); }
 };
 
 }  // namespace ez

--- a/test/test_imu_scale.cpp
+++ b/test/test_imu_scale.cpp
@@ -1,0 +1,86 @@
+// Verifies drive_imus_scalers_set()/_get() calibrate each redundant imu
+// independently: setting {3550, 3600, 3650} (each imu's raw reading after a
+// physical 3600 degree turn) must scale each imu's raw rotation by its own
+// 3600/value multiplier, not a shared one, and the getters must round-trip
+// per port.
+#include "doctest.h"
+
+#include "drive_test_access.hpp"
+
+using namespace ez;
+
+namespace {
+Drive make_chassis() {
+  test_stub::reset_all();
+  return Drive({1, -2}, {-3, 4}, {5, 6, 7}, 3.25, 360, 1.0);
+}
+}  // namespace
+
+TEST_CASE("imu scaler: default-constructed imus are unscaled") {
+  Drive chassis = make_chassis();
+
+  chassis.good_imus[0]->fake_rotation = 42.0;
+  chassis.good_imus[1]->fake_rotation = 42.0;
+  chassis.good_imus[2]->fake_rotation = 42.0;
+
+  for (auto* imu : chassis.good_imus)
+    CHECK(DriveTestAccess::get_this_imu(chassis, imu) == doctest::Approx(42.0));
+}
+
+TEST_CASE("imu scaler: drive_imus_scalers_set gives each imu its own scale") {
+  Drive chassis = make_chassis();
+
+  // Imu on good_imus[0] under-reports (3550 after a real 3600), good_imus[1]
+  // is spot on, good_imus[2] over-reports (3650).
+  chassis.drive_imus_scalers_set({3550.0, 3600.0, 3650.0});
+
+  chassis.good_imus[0]->fake_rotation = 90.0;
+  chassis.good_imus[1]->fake_rotation = 90.0;
+  chassis.good_imus[2]->fake_rotation = 90.0;
+
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[0]) == doctest::Approx(90.0 * 3600.0 / 3550.0));
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[1]) == doctest::Approx(90.0));
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[2]) == doctest::Approx(90.0 * 3600.0 / 3650.0));
+}
+
+TEST_CASE("imu scaler: drive_imus_scalers_get round-trips per port") {
+  Drive chassis = make_chassis();
+
+  chassis.drive_imus_scalers_set({3550.0, 3600.0, 3650.0});
+  std::map<int, double> readback = chassis.drive_imus_scalers_get();
+
+  CHECK(readback[chassis.good_imus[0]->get_port()] == doctest::Approx(3550.0));
+  CHECK(readback[chassis.good_imus[1]->get_port()] == doctest::Approx(3600.0));
+  CHECK(readback[chassis.good_imus[2]->get_port()] == doctest::Approx(3650.0));
+}
+
+TEST_CASE("imu scaler: drive_imu_scaler_set only touches the currently focused imu") {
+  Drive chassis = make_chassis();
+
+  // chassis.imu defaults to good_imus[0]; setting the single-imu scaler
+  // should not disturb the other two imus' scales.
+  chassis.drive_imu_scaler_set(3550.0);
+
+  chassis.good_imus[0]->fake_rotation = 90.0;
+  chassis.good_imus[1]->fake_rotation = 90.0;
+  chassis.good_imus[2]->fake_rotation = 90.0;
+
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[0]) == doctest::Approx(90.0 * 3600.0 / 3550.0));
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[1]) == doctest::Approx(90.0));
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[2]) == doctest::Approx(90.0));
+}
+
+TEST_CASE("imu scaler: rejects a 0 value and leaves the previous scale in place") {
+  Drive chassis = make_chassis();
+
+  chassis.drive_imus_scalers_set({3550.0, 3600.0, 3650.0});
+  chassis.drive_imus_scalers_set({0.0, 0.0, 0.0});  // must be rejected, not applied
+
+  chassis.good_imus[0]->fake_rotation = 90.0;
+  chassis.good_imus[1]->fake_rotation = 90.0;
+  chassis.good_imus[2]->fake_rotation = 90.0;
+
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[0]) == doctest::Approx(90.0 * 3600.0 / 3550.0));
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[1]) == doctest::Approx(90.0));
+  CHECK(DriveTestAccess::get_this_imu(chassis, chassis.good_imus[2]) == doctest::Approx(90.0 * 3600.0 / 3650.0));
+}


### PR DESCRIPTION
## Summary
- `drive_imu_scaler_set()` / `drive_imus_scalers_set()` now take the imu's raw reading after physically turning the robot 3600 degrees (10 full rotations) instead of an opaque multiplier you had to compute yourself.
- Internally this is converted to a multiplier as `3600.0 / value` and stored exactly as before; `get_this_imu()`, `drive_imu_reset()`, and the IMU watchdog in `maintenance.cpp` are unchanged since they only ever read the stored multiplier.
- Getters (`drive_imu_scaler_get()` / `drive_imus_scalers_get()`) are symmetric with the setters, returning the equivalent 3600-degree reading.
- Default-constructed drives are unaffected — their multiplier is set to `1.0` directly in each constructor, bypassing the new conversion, so an unconfigured IMU still reports its raw rotation unchanged.
- This is a breaking change to the meaning of the value passed to these functions (previously a multiplier, now a raw degree reading), consistent with the other 4.0 breaking changes already in flight.

Fixes #268

## Test plan
- [x] Host test suite: `make -C test` — 29/29 tests, 147/147 assertions passing
- [x] Library builds clean with `-Werror` via `make library EXTRA_CXXFLAGS='-Wno-deprecated-enum-enum-conversion -Werror'` (matches CI's `warnings-clean` job)
- [x] Verified defaults: a freshly constructed `Drive` with no scaler configured returns `get_this_imu() == imu->get_rotation()` (multiplier of 1.0)
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 9520f081984ce6660dbf9593f1e12f409e3fdd7e -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34107430332)
- via manual download: [EZ-Template@4.0.0+9520f0.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10012897130.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+9520f0.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10012897130.zip;
pros c fetch EZ-Template@4.0.0+9520f0.zip;
pros c apply EZ-Template@4.0.0+9520f0;
rm EZ-Template@4.0.0+9520f0.zip;
```