### PR TITLE
Remove auton mirroring (odom_x_flip/odom_y_flip/odom_theta_flip)

### DIFF
--- a/include/EZ-Template/drive/drive.hpp
+++ b/include/EZ-Template/drive/drive.hpp
@@ -690,51 +690,6 @@ class Drive {
   void odom_reset();
 
   /**
-   * Flips the X axis.
-   *
-   * \param flip
-   *        true means left is positive x, false means right is positive x
-   */
-  void odom_x_flip(bool flip = true);
-
-  /**
-   * Checks if X axis is flipped.
-   *
-   * True means left is positive X, false means right is positive X.
-   */
-  bool odom_x_direction_get();
-
-  /**
-   * Flips the Y axis.
-   *
-   * \param flip
-   *        true means down is positive y, false means up is positive y
-   */
-  void odom_y_flip(bool flip = true);
-
-  /**
-   * Checks if Y axis is flipped.
-   *
-   * True means down is positive Y, false means up is positive Y.
-   */
-  bool odom_y_direction_get();
-
-  /**
-   * Flips the rotation axis.
-   *
-   * \param flip
-   *        true means counterclockwise is positive, false means clockwise is positive
-   */
-  void odom_theta_flip(bool flip = true);
-
-  /**
-   * Checks if the rotation axis is flipped.
-   *
-   * True means counterclockwise is positive, false means clockwise is positive.
-   */
-  bool odom_theta_direction_get();
-
-  /**
    * Sets a new dlead.
    *
    * Dlead is a proportional value of how much to make the robot curve during boomerang motions.
@@ -3640,9 +3595,6 @@ class Drive {
   bool imu_only_imu_warning_shown = false;
 
   bool is_swing_slew_enabled(e_swing type, double target, double current);
-  // Converts a user-facing swing side to the internal side (mirrored when theta is flipped).
-  e_swing swing_type_internal(e_swing type);
-  // Runs the swing base with already-internal-frame type/target.  Does not flip.
   void swing_set_internal(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on);
   bool slew_reenables_when_max_speed_changes = true;
   int slew_min_when_it_enabled = 0;
@@ -3659,14 +3611,7 @@ class Drive {
   pose odom_start = {0.0, 0.0, 0.0};
   pose odom_target_start = {0.0, 0.0, 0.0};
   pose turn_to_point_target = {0.0, 0.0, 0.0};
-  bool y_flipped = false;
-  bool x_flipped = false;
-  bool theta_flipped = false;
-  double flip_angle_target(double target);
-  // Runs the turn base with an already-internal-frame target.  Does not flip.
   void turn_set_internal(double target, int speed, e_angle_behavior behavior, bool slew_on);
-  // The current heading target expressed in the user's frame (undoes the internal flip).
-  double heading_target_user_frame();
   double odom_imu_start = 0.0;
   int past_target = 0;
   double SPACING = 0.5;
@@ -3700,9 +3645,6 @@ class Drive {
   e_angle_behavior default_turn_type = raw;
   e_angle_behavior default_odom_type = shortest;
   bool turn_biased_left = false;
-  std::vector<odom> set_odoms_direction(std::vector<odom> inputs);
-  odom set_odom_direction(odom input);
-  pose flip_pose(pose input);
   bool odom_tracker_left_enabled = false;
   bool odom_tracker_right_enabled = false;
   bool odom_tracker_front_enabled = false;

--- a/src/EZ-Template/drive/exit_conditions.cpp
+++ b/src/EZ-Template/drive/exit_conditions.cpp
@@ -251,12 +251,12 @@ void Drive::wait_until_drive(double target) {
 
 // Function to wait until a certain position is reached.  Wrapper for exit condition.
 void Drive::wait_until_turn_swing(double target) {
-  // Flip into the internal frame and resolve using the motion's own behavior
-  target = new_turn_target_compute(flip_angle_target(target), drive_angle_get(), current_angle_behavior);
+  // Resolve using the motion's own behavior
+  target = new_turn_target_compute(target, drive_angle_get(), current_angle_behavior);
   wait_until_turn_swing_internal(target);
 }
 
-// Expects an already-resolved, internal-frame absolute target.  Does not flip or re-resolve behavior.
+// Expects an already-resolved absolute target.  Does not re-resolve behavior.
 void Drive::wait_until_turn_swing_internal(double target) {
   // Make sure mode is correct
   if (!(mode == TURN || mode == SWING || mode == TURN_TO_POINT)) {

--- a/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_odom_pid.cpp
@@ -18,35 +18,6 @@ void Drive::odom_path_print() {
 }
 void Drive::pid_odom_behavior_set(ez::e_angle_behavior behavior) { default_odom_type = behavior; }
 ez::e_angle_behavior Drive::pid_odom_behavior_get() { return default_odom_type; }
-// Flip all inputs so it works internally
-pose Drive::flip_pose(pose input) {
-  int flip_x = x_flipped ? -1 : 1;
-  int flip_y = y_flipped ? -1 : 1;
-
-  pose new_pose = input;
-  new_pose.x *= flip_x;
-  new_pose.y *= flip_y;
-  if (new_pose.theta != ANGLE_NOT_SET)
-    new_pose.theta = flip_angle_target(new_pose.theta);
-
-  return new_pose;
-}
-std::vector<odom> Drive::set_odoms_direction(std::vector<odom> inputs) {
-  std::vector<odom> output;
-
-  for (std::size_t i = 0; i < inputs.size(); i++) {
-    pose new_pose = flip_pose(inputs[i].target);
-    output.push_back({new_pose,
-                      inputs[i].drive_direction,
-                      inputs[i].max_xy_speed,
-                      inputs[i].turn_behavior});
-  }
-
-  return output;
-}
-odom Drive::set_odom_direction(odom input) {
-  return set_odoms_direction({input})[0];
-}
 void Drive::pid_odom_angular_constants_set(double p, double i, double d, double p_start_i) {
   odom_angularPID.constants_set(p, i, d, p_start_i);
 }
@@ -75,12 +46,6 @@ std::vector<double> Drive::odom_path_smooth_constants_get() {
   return {odom_smooth_weight_smooth, odom_smooth_weight_data, odom_smooth_tolerance};
 }
 
-void Drive::odom_x_flip(bool flip) { x_flipped = flip; }
-bool Drive::odom_x_direction_get() { return x_flipped; }
-void Drive::odom_y_flip(bool flip) { y_flipped = flip; }
-bool Drive::odom_y_direction_get() { return y_flipped; }
-void Drive::odom_theta_flip(bool flip) { theta_flipped = flip; }
-bool Drive::odom_theta_direction_get() { return theta_flipped; }
 void Drive::odom_boomerang_dlead_set(double input) { dlead = input; }
 double Drive::odom_boomerang_dlead_get() { return dlead; }
 void Drive::odom_boomerang_distance_set(double distance) { max_boomerang_distance = distance; }
@@ -261,7 +226,7 @@ void Drive::pid_odom_injected_pp_set(std::vector<ez::odom> imovements, bool slew
   rightPID.motion_reset(drive_sensor_right());
 
   if (print_toggle) printf("Injected ");
-  std::vector<odom> input_path = inject_points(set_odoms_direction(imovements));
+  std::vector<odom> input_path = inject_points(imovements);
   odom_turn_bias_enable(true);
   current_slew_on = slew_on;
   slew_min_when_it_enabled = 0;
@@ -301,7 +266,7 @@ void Drive::pid_odom_smooth_pp_set(std::vector<odom> imovements, bool slew_on) {
   rightPID.motion_reset(drive_sensor_right());
 
   if (print_toggle) printf("Smooth Injected ");
-  std::vector<odom> input_path = smooth_path(inject_points(set_odoms_direction(imovements)), odom_smooth_weight_smooth, odom_smooth_weight_data, odom_smooth_tolerance);
+  std::vector<odom> input_path = smooth_path(inject_points(imovements), odom_smooth_weight_smooth, odom_smooth_weight_data, odom_smooth_tolerance);
   odom_turn_bias_enable(true);
   current_slew_on = slew_on;
   slew_min_when_it_enabled = 0;
@@ -358,7 +323,7 @@ void Drive::pid_odom_pp_set(std::vector<odom> imovements, bool slew_on) {
   leftPID.motion_reset(drive_sensor_left());
   rightPID.motion_reset(drive_sensor_right());
 
-  std::vector<odom> input = set_odoms_direction(imovements);
+  std::vector<odom> input = imovements;
   input.insert(input.begin(), {{{odom_x_get(), odom_y_get(), ANGLE_NOT_SET}, imovements[0].drive_direction, imovements[0].max_xy_speed}});
 
   int t = 0;
@@ -409,8 +374,6 @@ void Drive::pid_odom_ptp_set(odom imovement, bool slew_on) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
   interfered = false;
-
-  imovement = set_odom_direction(imovement);
 
   odom_second_to_last = odom_pose_get();
   odom_target_start = imovement.target;

--- a/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_swing_pid.cpp
@@ -83,19 +83,10 @@ void Drive::slew_swing_forward_set(bool slew_on) { global_forward_swing_slew_ena
 bool Drive::slew_swing_forward_get() { return global_forward_swing_slew_enabled; }
 void Drive::slew_swing_backward_set(bool slew_on) { global_backward_swing_slew_enabled = slew_on; }
 bool Drive::slew_swing_backward_get() { return global_backward_swing_slew_enabled; }
-// Converts a user-facing swing side to the internal side (mirrored when theta is flipped)
-e_swing Drive::swing_type_internal(e_swing type) {
-  if (odom_theta_direction_get())
-    return type == ez::LEFT_SWING ? ez::RIGHT_SWING : ez::LEFT_SWING;
-  return type;
-}
-
 // Checks if slew is globally enabled or not
 bool Drive::is_swing_slew_enabled(e_swing type, double target, double current) {
-  e_swing internal_type = swing_type_internal(type);
-  double internal_target = flip_angle_target(target);
-  int side = internal_type == ez::LEFT_SWING ? 1 : -1;
-  int direction = util::sgn((internal_target - current) * side);
+  int side = type == ez::LEFT_SWING ? 1 : -1;
+  int direction = util::sgn((target - current) * side);
   return direction == 1 ? slew_swing_forward_get() : slew_swing_backward_get();
 }
 
@@ -118,7 +109,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed) {
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed) {
   // Figure out if going forward or backward
-  double absolute_heading = target + heading_target_user_frame();
+  double absolute_heading = target + headingPID.target_get();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, 0, pid_swing_behavior_get(), slew_on);
 }
@@ -142,7 +133,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, e_ang
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, e_angle_behavior behavior) {
   // Figure out if going forward or backward
-  double absolute_heading = target + heading_target_user_frame();
+  double absolute_heading = target + headingPID.target_get();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, 0, behavior, slew_on);
 }
@@ -166,7 +157,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 }
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed) {
-  double absolute_heading = target + heading_target_user_frame();
+  double absolute_heading = target + headingPID.target_get();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, opposite_speed, pid_swing_behavior_get(), slew_on);
 }
@@ -209,7 +200,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 }
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior) {
-  double absolute_heading = target + heading_target_user_frame();
+  double absolute_heading = target + headingPID.target_get();
   bool slew_on = is_swing_slew_enabled(type, absolute_heading, drive_angle_get());
   pid_swing_relative_set(type, target, speed, opposite_speed, behavior, slew_on);
 }
@@ -232,7 +223,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed, bool slew_on) {
   // Compute absolute target by adding to current heading
-  double absolute_target = heading_target_user_frame() + target;
+  double absolute_target = headingPID.target_get() + target;
   if (print_toggle) printf("Relative ");
   pid_swing_set(type, absolute_target, speed, opposite_speed, pid_swing_behavior_get(), slew_on);
 }
@@ -255,7 +246,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, e_ang
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, e_angle_behavior behavior, bool slew_on) {
   // Compute absolute target by adding to current heading
-  double absolute_target = heading_target_user_frame() + target;
+  double absolute_target = headingPID.target_get() + target;
   if (print_toggle) printf("Relative ");
   pid_swing_set(type, absolute_target, speed, 0, behavior, slew_on);
 }
@@ -275,7 +266,7 @@ void Drive::pid_swing_set(e_swing type, okapi::QAngle p_target, int speed, int o
 // Relative
 void Drive::pid_swing_relative_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
   // Compute absolute target by adding to current heading
-  double absolute_target = heading_target_user_frame() + target;
+  double absolute_target = headingPID.target_get() + target;
   if (print_toggle) printf("Relative ");
   pid_swing_set(type, absolute_target, speed, opposite_speed, behavior, slew_on);
 }
@@ -288,7 +279,7 @@ void Drive::pid_swing_relative_set(e_swing type, okapi::QAngle p_target, int spe
 // Swing set base
 /////
 void Drive::pid_swing_set(e_swing type, double target, int speed, int opposite_speed, e_angle_behavior behavior, bool slew_on) {
-  swing_set_internal(swing_type_internal(type), flip_angle_target(target), speed, opposite_speed, behavior, slew_on);
+  swing_set_internal(type, target, speed, opposite_speed, behavior, slew_on);
 }
 
 /////

--- a/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
+++ b/src/EZ-Template/drive/set_pid/set_turn_pid.cpp
@@ -30,16 +30,6 @@ ez::e_angle_behavior Drive::pid_turn_behavior_get() { return default_turn_type; 
 void Drive::slew_turn_set(bool slew_on) { global_turn_slew_enabled = slew_on; }
 bool Drive::slew_turn_get() { return global_turn_slew_enabled; }
 
-double Drive::flip_angle_target(double target) {
-  int flip_theta = theta_flipped ? -1 : 1;
-  double new_target = target;
-  new_target *= flip_theta;
-  return new_target;
-}
-
-// The current heading target expressed in the user's frame (undoes the internal flip)
-double Drive::heading_target_user_frame() { return flip_angle_target(headingPID.target_get()); }
-
 /////
 // Set turn PID basic wrappers
 /////
@@ -107,7 +97,7 @@ void Drive::pid_turn_set(okapi::QAngle p_target, int speed, e_angle_behavior beh
 // Relative
 void Drive::pid_turn_relative_set(double target, int speed, e_angle_behavior behavior, bool slew_on) {
   // Compute absolute target by adding to current heading (both in the user's frame)
-  double absolute_target = heading_target_user_frame() + target;
+  double absolute_target = headingPID.target_get() + target;
   if (print_toggle) printf("Relative ");
   pid_turn_set(absolute_target, speed, behavior, slew_on);
 }
@@ -120,7 +110,7 @@ void Drive::pid_turn_relative_set(okapi::QAngle p_target, int speed, e_angle_beh
 // Turn to angle base
 /////
 void Drive::pid_turn_set(double target, int speed, e_angle_behavior behavior, bool slew_on) {
-  turn_set_internal(flip_angle_target(target), speed, behavior, slew_on);
+  turn_set_internal(target, speed, behavior, slew_on);
 }
 
 /////
@@ -192,7 +182,6 @@ void Drive::pid_turn_set(united_pose p_itarget, drive_directions dir, int speed,
 void Drive::pid_turn_set(pose itarget, drive_directions dir, int speed, e_angle_behavior behavior, bool slew_on) {
   std::lock_guard<pros::RecursiveMutex> lock(drive_mutex);
 
-  itarget = flip_pose(itarget);
   odom_imu_start = drive_angle_get();
 
   current_drive_direction = dir;

--- a/test/drive_test_access.hpp
+++ b/test/drive_test_access.hpp
@@ -35,7 +35,6 @@ struct DriveTestAccess {
   static bool is_swing_slew_enabled(Drive& d, e_swing type, double target, double current) {
     return d.is_swing_slew_enabled(type, target, current);
   }
-  static e_swing swing_type_internal(Drive& d, e_swing type) { return d.swing_type_internal(type); }
 };
 
 }  // namespace ez

--- a/test/test_turns.cpp
+++ b/test/test_turns.cpp
@@ -1,9 +1,5 @@
-// With odom_theta_flip(true), pid_turn_set(90) then pid_turn_relative_set(45)
-// leaves headingPID.target_get() at -135; pid_turn_set({24,24}, fwd) with x
-// and theta flipped leaves it at -45; pid_swing_set(LEFT_SWING, 90, 110, 45)
-// mirrored selects the forward slew constants; the turn-min gate does not
-// engage for an 88 -> 90 turn and does engage inside start_i for a 0 -> 90
-// turn.
+// The turn-min gate does not engage for an 88 -> 90 turn and does engage
+// inside start_i for a 0 -> 90 turn.
 #include "doctest.h"
 
 #include "drive_test_access.hpp"
@@ -16,48 +12,6 @@ Drive make_chassis() {
   return Drive({1, -2}, {-3, 4}, 5, 3.25, 360, 1.0);
 }
 }  // namespace
-
-TEST_CASE("turns pid_turn_set then pid_turn_relative_set with theta flipped") {
-  Drive chassis = make_chassis();
-  chassis.odom_theta_flip(true);
-
-  chassis.pid_turn_set(90.0, 100);
-  chassis.pid_turn_relative_set(45.0, 100);
-
-  CHECK(chassis.headingPID.target_get() == doctest::Approx(-135));
-}
-
-TEST_CASE("turns pid_turn_set(pose) with x and theta flipped") {
-  Drive chassis = make_chassis();
-  chassis.odom_x_flip(true);
-  chassis.odom_theta_flip(true);
-
-  chassis.pid_turn_set(pose{24, 24}, fwd, 100);
-
-  // Derived by running find_point_to_face()'s trig (look-ahead point
-  // selection, then absolute_angle_to_point()) rather than hand-computed:
-  // that path has no closed form worth re-deriving by inspection alone.
-  CHECK(chassis.headingPID.target_get() == doctest::Approx(-45));
-}
-
-TEST_CASE("turns mirrored LEFT_SWING selects the forward slew constants") {
-  Drive chassis = make_chassis();
-  chassis.odom_theta_flip(true);  // mirrors LEFT_SWING <-> RIGHT_SWING
-
-  chassis.slew_swing_constants_forward_set(6_in, 70);
-  chassis.slew_swing_constants_backward_set(3_in, 40);
-
-  chassis.pid_swing_set(LEFT_SWING, 90.0, 110, 45);
-
-  // swing_set_internal() picks forward/backward slew constants by the sign
-  // of (target - chain_sensor_start) in the *internal* (post-mirror) frame;
-  // with theta flipped, LEFT_SWING becomes RIGHT_SWING and the target flips
-  // sign too, and the two flips land on "forward" here. distance_to_travel
-  // is in inches (6) since these were set via the QLength overload.
-  DriveTestAccess::is_swing_slew_enabled(chassis, LEFT_SWING, 90.0, 0.0);  // no-op sanity call, doesn't throw
-  CHECK(chassis.slew_swing.constants_get().distance_to_travel == doctest::Approx(6));
-  CHECK(chassis.slew_swing.constants_get().min_speed == doctest::Approx(70));
-}
 
 TEST_CASE("turns turn-min gate does not engage for an 88 -> 90 turn") {
   Drive chassis = make_chassis();


### PR DESCRIPTION
## Summary
- Removes the axis-flip mirroring API and the internal frame-conversion machinery it drove:
  - Public: `odom_x_flip()`, `odom_y_flip()`, `odom_theta_flip()`, `odom_x_direction_get()`, `odom_y_direction_get()`, `odom_theta_direction_get()`
  - Internal: `flip_pose()`, `set_odom_direction()` / `set_odoms_direction()`, `flip_angle_target()`, `heading_target_user_frame()`, `swing_type_internal()`, and the `x_flipped` / `y_flipped` / `theta_flipped` state
- Mirroring requires a mechanically symmetric robot and a perfectly centered tracking center, and rarely works out of the box — it was a High Stakes-era addition that's since proven to be more of a trap for new programmers than a reliable path to red/blue autons.
- Every call site that funneled through the flip helpers (odom targets, turn targets, swing targets, the turn/swing exit-condition wait path) now uses its target directly.
- Removes the three host tests in `test_turns.cpp` that exercised flipped turns/swings and the `swing_type_internal` test-access shim; the two turn-min gate tests are unaffected.

Fixes #371

## Test plan
- [x] Host test suite: `make -C test` — 26/26 tests, 143/143 assertions passing (down from 29/147 by the 3 removed flip-specific tests)
- [x] Library builds clean with `-Werror` via `make library EXTRA_CXXFLAGS='-Wno-deprecated-enum-enum-conversion -Werror'` (matches CI's `warnings-clean` job)
- [x] Repo-wide grep for every removed symbol (`x_flipped`, `y_flipped`, `theta_flipped`, `flip_pose`, `flip_angle_target`, `set_odom_direction`, `set_odoms_direction`, `swing_type_internal`, `odom_*_flip`, `odom_*_direction_get`, `heading_target_user_frame`) returns zero hits

## Follow-up
The `mirror_autons.md` tutorial on the `website` branch documents this API and should be removed in a companion docs PR — happy to open that too, just didn't want to bundle a docs change into a code PR per the branch split. `onBrokenLinks` is set to `throw` there, so removing the page needs its sidebar/inbound-link references cleaned up in the same PR.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: b8a6d9a5de27948ca40977c7ee7362d7b4d60f6b -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/EZ-Robotics/EZ-Template/actions/runs/34104840155)
- via manual download: [EZ-Template@4.0.0+b8a6d9.zip](https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10011899551.zip)
- via PROS Integrated Terminal: 
 ```
curl -o EZ-Template@4.0.0+b8a6d9.zip https://nightly.link/EZ-Robotics/EZ-Template/actions/artifacts/10011899551.zip;
pros c fetch EZ-Template@4.0.0+b8a6d9.zip;
pros c apply EZ-Template@4.0.0+b8a6d9;
rm EZ-Template@4.0.0+b8a6d9.zip;
```